### PR TITLE
Refactor tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@babel/preset-env": "^7.16.11",
     "@babel/preset-react": "^7.16.7",
     "@babel/register": "^7.17.7",
-    "deep-equal": "^2.0.5",
     "eslint": "^8.12.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-babel": "^5.3.1",
@@ -45,8 +44,7 @@
     "redux": "^4.1.2",
     "redux-thunk": "^2.4.1",
     "rimraf": "^3.0.2",
-    "sinon": "^13.0.1",
-    "tcomb": "^3.2.15"
+    "sinon": "^13.0.1"
   },
   "peerDependencies": {
     "prop-types": "^15.7.2",

--- a/src/tests/ReactLifeCycle.spec.js
+++ b/src/tests/ReactLifeCycle.spec.js
@@ -1,9 +1,9 @@
 const { describe, it } = global;
+import assert from 'assert/strict';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { renderToString } from 'react-dom/server';
 import sinon from 'sinon';
-import t from 'tcomb';
 
 describe('React lifecycle methods', () => {
   class CompositeComponent extends Component {
@@ -37,7 +37,7 @@ describe('React lifecycle methods', () => {
         spyForComponentWillUnmount={spyForComponentWillUnmount}
       />,
     );
-    t.assert(
+    assert(
       spyForComponentWillMount.calledOnce,
       '#componentWillMount() has been called once',
     );
@@ -52,8 +52,8 @@ describe('React lifecycle methods', () => {
         spyForComponentWillUnmount={spyForComponentWillUnmount}
       />,
     );
-    t.assert(
-      spyForComponentWillUnmount.callCount === 0,
+    assert(
+      spyForComponentWillUnmount.notCalled,
       '#componentWillUnmount() has not been called',
     );
   });

--- a/src/tests/dispatched.spec.js
+++ b/src/tests/dispatched.spec.js
@@ -1,6 +1,6 @@
 const { describe, it } = global;
+import assert from 'assert/strict';
 import url from 'url';
-import t from 'tcomb';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { renderToStaticMarkup } from 'react-dom/server';
@@ -178,9 +178,9 @@ describe('dispatched', () => {
 
       await prepare(app);
       const html = renderToStaticMarkup(app);
-      t.assert(
-        html ===
-          '<ul><li><div>echo /foo</div></li><li><div>echo /bar</div></li></ul>',
+      assert.equal(
+        html,
+        '<ul><li><div>echo /foo</div></li><li><div>echo /bar</div></li></ul>',
         'renders correct html',
       );
     } finally {

--- a/src/tests/isReactCompositeComponent.spec.js
+++ b/src/tests/isReactCompositeComponent.spec.js
@@ -1,5 +1,5 @@
 const { describe, it } = global;
-import t from 'tcomb';
+import assert from 'assert/strict';
 import React from 'react';
 import { Provider } from 'react-redux';
 
@@ -12,7 +12,7 @@ describe('isReactCompositeComponent', () => {
         return <div />;
       }
     }
-    t.assert(isReactCompositeComponent(C), 'match Component');
+    assert(isReactCompositeComponent(C), 'match Component');
   });
 
   it('should match PureComponent', () => {
@@ -21,18 +21,18 @@ describe('isReactCompositeComponent', () => {
         return <div />;
       }
     }
-    t.assert(isReactCompositeComponent(C), 'match PureComponent');
+    assert(isReactCompositeComponent(C), 'match PureComponent');
   });
 
   it('should not match functional component', () => {
     const C = () => <div />;
-    t.assert(
+    assert(
       isReactCompositeComponent(C) === false,
       'not match functional component',
     );
   });
 
   it('should match redux Provider', () => {
-    t.assert(isReactCompositeComponent(Provider), 'match redux Provider');
+    assert(isReactCompositeComponent(Provider), 'match redux Provider');
   });
 });

--- a/src/tests/isThenable.spec.js
+++ b/src/tests/isThenable.spec.js
@@ -1,34 +1,34 @@
 const { describe, it } = global;
-import t from 'tcomb';
+import assert from 'assert/strict';
 
 import isThenable from '../utils/isThenable';
 
 describe('isThenable(p)', () => {
   it('recognizes a native Promise as thenable', () => {
-    t.assert(isThenable(Promise.resolve()));
+    assert(isThenable(Promise.resolve()));
   });
 
   it('recognizes null as non-thenable', () => {
-    t.assert(!isThenable(null));
+    assert(!isThenable(null));
   });
 
   it('recognizes void 0 as non-thenable', () => {
-    t.assert(!isThenable(void 0));
+    assert(!isThenable(void 0));
   });
 
   it('recognizes function as non-thenable', () => {
     function nonThenable() {}
-    t.assert(!isThenable(nonThenable));
+    assert(!isThenable(nonThenable));
   });
 
   it('recognizes arrow as non-thenable', () => {
-    t.assert(!isThenable(() => {}));
+    assert(!isThenable(() => {}));
   });
 
   it('recognizes custom thenable as thenable', () => {
     const thenable = {
       then: () => Promise.resolve(),
     };
-    t.assert(isThenable(thenable));
+    assert(isThenable(thenable));
   });
 });

--- a/src/tests/prepare.spec.js
+++ b/src/tests/prepare.spec.js
@@ -1,7 +1,6 @@
 const { describe, it } = global;
-import t from 'tcomb';
+import assert from 'assert/strict';
 import sinon from 'sinon';
-import equal from 'deep-equal';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { renderToStaticMarkup } from 'react-dom/server';
@@ -20,14 +19,15 @@ describe('prepare', () => {
       }
 
       render() {
-        t.assert(
-          equal(this.props, { message: 'Hello' }),
+        assert.deepEqual(
+          this.props,
+          { message: 'Hello' },
           'sets props on instance',
         );
-        t.assert(this.state === null, 'sets state on instance');
-        t.assert(this.updater !== undefined, 'sets updater on instance');
-        t.assert(equal(this.refs, {}), 'sets refs on instance'); // eslint-disable-line react/no-string-refs
-        t.assert(equal(this.context, {}), 'sets context on instance');
+        assert.equal(this.state, null, 'sets state on instance');
+        assert.notEqual(this.updater, undefined, 'sets updater on instance');
+        assert.deepEqual(this.refs, {}, 'sets refs on instance'); // eslint-disable-line react/no-string-refs
+        assert.deepEqual(this.context, {}, 'sets context on instance');
         return null;
       }
     }
@@ -52,8 +52,9 @@ describe('prepare', () => {
       }
 
       render() {
-        t.assert(
-          equal(this.state.message, 'Updated message'),
+        assert.deepEqual(
+          this.state,
+          { message: 'Updated message' },
           'updates state on instance',
         );
         return null;
@@ -83,10 +84,11 @@ describe('prepare', () => {
         </App>,
       );
     } catch (err) {
-      t.assert(doAsyncSideEffect.calledOnce, 'Should be called once times');
+      assert.equal(err.message, 'Err', 'Should throw the correct error');
+      assert(doAsyncSideEffect.calledOnce, 'Should be called once times');
       return;
     }
-    t.assert(false, 'It should throw');
+    assert.fail('It should throw');
   });
 
   it("Should be possible to don't throw exception", async () => {
@@ -97,7 +99,6 @@ describe('prepare', () => {
     const prepareUsingProps = async ({ text }) => {
       await doAsyncSideEffect(text);
     };
-    const options = { errorHandler: (e) => e };
 
     const App = prepared(prepareUsingProps)(({ text, children }) => (
       <div>
@@ -109,9 +110,9 @@ describe('prepare', () => {
         <App text="foo" />
         <App text="foo" />
       </App>,
-      options,
+      { errorHandler: (e) => e },
     );
-    t.assert(doAsyncSideEffect.calledThrice, 'Should be called 3 times');
+    assert(doAsyncSideEffect.calledThrice, 'Should be called 3 times');
   });
 
   it('Should handle data deps properly in correct order', async () => {
@@ -145,8 +146,9 @@ describe('prepare', () => {
         </Inner>
       </Outer>,
     );
-    t.assert(
-      equal(execOrder, ['inner', 'inner', 'inner', 'outer']),
+    assert.deepEqual(
+      execOrder,
+      ['inner', 'inner', 'inner', 'outer'],
       'outer should be resolved last',
     );
   });
@@ -166,9 +168,10 @@ describe('prepare', () => {
         {text} <div>{children ? children : null}</div>
       </div>
     ));
-    /* eslint-disable react/prop-types */
+
     const Testing = ({ children }) => <div>Test {children} </div>;
-    /* eslint-enable react/prop-types */
+    Testing.propTypes = { children: PropTypes.node };
+
     await prepare(
       <App text="foo">
         <App text="foo" />
@@ -178,8 +181,9 @@ describe('prepare', () => {
       </App>,
       options,
     );
-    t.assert(doAsyncSideEffect.calledThrice, 'Should be called 3 times');
+    assert(doAsyncSideEffect.calledThrice, 'Should be called 3 times');
   });
+
   it('Should support <React.Forwardref />', async () => {
     // eslint-disable-next-line react/display-name
     const RefSetter = React.forwardRef((props, ref) => {
@@ -209,29 +213,29 @@ describe('prepare', () => {
     );
     await prepare(<App />);
 
-    t.assert(
-      refToRead.current === 'data is correct',
+    assert.equal(
+      refToRead.current,
+      'data is correct',
       'ref value should presist',
     );
-    t.assert(refToSet.current === 'hi', 'ref value should be set');
-    t.assert(
+    assert.equal(refToSet.current, 'hi', 'ref value should be set');
+    assert(
       RefUserTester.calledOnce,
       'Should only be called once during prepare',
     );
-    t.assert(
+    assert(
       RefUserTester.calledOnce,
       'Should only be called once during prepare',
     );
-    t.assert(
-      equal(RefUserTester.getCall(0).args, [
-        { children: 'This is a ref user test' },
-        { current: 'data is correct' },
-      ]),
+    assert.deepEqual(
+      RefUserTester.getCall(0).args,
+      [{ children: 'This is a ref user test' }, { current: 'data is correct' }],
+      'Props and ref should be correct',
     );
     const html = renderToStaticMarkup(<App />);
-    t.assert(
-      html ===
-        '<p id="test">This is a ref setter test - hi</p><p id="test2">This is a ref user test - data is correct</p>',
+    assert.equal(
+      html,
+      '<p id="test">This is a ref setter test - hi</p><p id="test2">This is a ref user test - data is correct</p>',
       'App should render with correct html',
     );
   });
@@ -250,18 +254,19 @@ describe('prepare', () => {
       </React.Fragment>,
     );
 
-    t.assert(
+    assert(
       prepareUsingProps.calledTwice,
       'prepareUsingProps has been called twice',
     );
-    t.assert(
+    assert(
       doAsyncSideEffect.calledTwice,
       'doAsyncSideEffect has been called twice',
     );
     const html = renderToStaticMarkup(<App text="foo" />);
-    t.assert(html === '<div>foo</div>', 'renders with correct html');
+    assert.equal(html, '<div>foo</div>', 'renders with correct html');
   });
-  it('Should support React Contexts />', async () => {
+
+  it('Should support React Contexts', async () => {
     const MyContext = React.createContext('initial');
     const Func = sinon.spy(() => null);
     const AnotherContext = React.createContext();
@@ -292,15 +297,17 @@ describe('prepare', () => {
       </MyContext.Consumer>
     );
     await prepare(<App />);
-    t.assert(Func.calledOnce, 'Func has been called exactly once');
-    t.assert(
-      equal(Func.getCall(0).args, ['testing']),
+    assert(Func.calledOnce, 'Func has been called exactly once');
+    assert.deepEqual(
+      Func.getCall(0).args,
+      ['testing'],
       'Func should be called with testing as arg',
     );
 
     const html = renderToStaticMarkup(<App />);
-    t.assert(
-      html === 'initial testing initial another',
+    assert.equal(
+      html,
+      'initial testing initial another',
       'renders with correct html',
     );
   });
@@ -312,24 +319,26 @@ describe('prepare', () => {
     });
     const App = prepared(prepareUsingProps)(({ text }) => <div>{text}</div>);
     await prepare(<App text="foo" />);
-    t.assert(
+    assert(
       prepareUsingProps.calledOnce,
       'prepareUsingProps has been called exactly once',
     );
-    t.assert(
-      equal(prepareUsingProps.getCall(0).args, [{ text: 'foo' }, {}]),
+    assert.deepEqual(
+      prepareUsingProps.getCall(0).args,
+      [{ text: 'foo' }, {}],
       'prepareUsingProps has been called with correct arguments',
     );
-    t.assert(
+    assert(
       doAsyncSideEffect.calledOnce,
       'doAsyncSideEffect has been called exactly once',
     );
-    t.assert(
-      equal(doAsyncSideEffect.getCall(0).args, ['foo']),
+    assert.deepEqual(
+      doAsyncSideEffect.getCall(0).args,
+      ['foo'],
       'doAsyncSideEffect has been called with correct arguments',
     );
     const html = renderToStaticMarkup(<App text="foo" />);
-    t.assert(html === '<div>foo</div>', 'renders with correct html');
+    assert.equal(html, '<div>foo</div>', 'renders with correct html');
   });
 
   it('Deep hierarchy', async () => {
@@ -371,50 +380,48 @@ describe('prepare', () => {
 
     await prepare(<App texts={['first', 'second']} />);
 
-    t.assert(
+    assert(
       prepareUsingPropsForFirstChild.calledOnce,
       'prepareUsingPropsForFirstChild has been called exactly once',
     );
-    t.assert(
-      equal(prepareUsingPropsForFirstChild.getCall(0).args, [
-        { text: 'first' },
-        {},
-      ]),
+    assert.deepEqual(
+      prepareUsingPropsForFirstChild.getCall(0).args,
+      [{ text: 'first' }, {}],
       'prepareUsingPropsForFirstChild has been called with correct arguments',
     );
-    t.assert(
+    assert(
       doAsyncSideEffectForFirstChild.calledOnce,
       'doAsyncSideEffectForFirstChild has been called exactly once',
     );
-    t.assert(
-      equal(doAsyncSideEffectForFirstChild.getCall(0).args, ['first']),
+    assert.deepEqual(
+      doAsyncSideEffectForFirstChild.getCall(0).args,
+      ['first'],
       'doAsyncSideEffectForFirstChild has been called with correct arguments',
     );
 
-    t.assert(
+    assert(
       prepareUsingPropsForSecondChild.calledOnce,
       'prepareUsingPropsForSecondChild has been called exactly once',
     );
-    t.assert(
-      equal(prepareUsingPropsForSecondChild.getCall(0).args, [
-        { text: 'second' },
-        {},
-      ]),
+    assert.deepEqual(
+      prepareUsingPropsForSecondChild.getCall(0).args,
+      [{ text: 'second' }, {}],
       'prepareUsingPropsForSecondChild has been called with correct arguments',
     );
-    t.assert(
+    assert(
       doAsyncSideEffectForSecondChild.calledOnce,
       'doAsyncSideEffectForSecondChild has been called exactly once',
     );
-    t.assert(
-      equal(doAsyncSideEffectForSecondChild.getCall(0).args, ['second']),
+    assert.deepEqual(
+      doAsyncSideEffectForSecondChild.getCall(0).args,
+      ['second'],
       'doAsyncSideEffectForSecondChild has been called with correct arguments',
     );
 
     const html = renderToStaticMarkup(<App texts={['first', 'second']} />);
-    t.assert(
-      html ===
-        '<ul><li><span class="prepared(FirstChild)">first</span></li><li><span class="prepared(SecondChild)">second</span></li></ul>',
-    ); // eslint-disable-line max-len
+    assert.equal(
+      html,
+      '<ul><li><span class="prepared(FirstChild)">first</span></li><li><span class="prepared(SecondChild)">second</span></li></ul>',
+    );
   });
 });

--- a/src/tests/prepared.spec.js
+++ b/src/tests/prepared.spec.js
@@ -1,7 +1,7 @@
+import assert from 'assert/strict';
+
 const { describe, it } = global;
 import sinon from 'sinon';
-import t from 'tcomb';
-import equal from 'deep-equal';
 import React, { Component, PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { renderToStaticMarkup } from 'react-dom/server';
@@ -40,40 +40,43 @@ describe('prepared', () => {
     const PreparedCompositeComponent = prepared(prepareUsingProps, {
       pure: false,
     })(OriginalCompositeComponent);
-    t.assert(
+    assert(
       !isPrepared(OriginalCompositeComponent),
       'OriginalComponent is not prepared',
     );
-    t.assert(
+    assert(
       isPrepared(PreparedCompositeComponent),
       'PreparedComponent is prepared',
     );
     const prepare = getPrepare(PreparedCompositeComponent);
-    t.assert(
-      typeof prepare === 'function',
+    assert.equal(
+      typeof prepare,
+      'function',
       'getPrepare(PreparedCompositeComponent) is a function',
     );
     await prepare({ text: 'foo' });
-    t.assert(
+    assert(
       prepareUsingProps.calledOnce,
       'prepareUsingProps has been called exactly once',
     );
-    t.assert(
-      equal(prepareUsingProps.getCall(0).args, [{ text: 'foo' }]),
+    assert.deepEqual(
+      prepareUsingProps.getCall(0).args,
+      [{ text: 'foo' }],
       'prepareUsingProps has been called with correct arguments',
     );
-    t.assert(
+    assert(
       doAsyncSideEffect.calledOnce,
       'doAsyncSideEffect has been called exactly once',
     );
-    t.assert(
-      equal(doAsyncSideEffect.getCall(0).args, ['foo']),
+    assert.deepEqual(
+      doAsyncSideEffect.getCall(0).args,
+      ['foo'],
       'doAsyncSideEffect has been called with correct arguments',
     );
     const html = renderToStaticMarkup(
       <PreparedCompositeComponent text="foo" />,
     );
-    t.assert(html === '<div>foo</div>', 'renders with correct html');
+    assert.equal(html, '<div>foo</div>', 'renders with correct html');
   });
 
   it('prepared Composite Pure Component', async () => {
@@ -84,40 +87,43 @@ describe('prepared', () => {
     const PreparedCompositeComponent = prepared(prepareUsingProps)(
       OriginalCompositePureComponent,
     );
-    t.assert(
+    assert(
       !isPrepared(OriginalCompositePureComponent),
       'OriginalComponent is not prepared',
     );
-    t.assert(
+    assert(
       isPrepared(PreparedCompositeComponent),
       'PreparedComponent is prepared',
     );
     const prepare = getPrepare(PreparedCompositeComponent);
-    t.assert(
-      typeof prepare === 'function',
+    assert.equal(
+      typeof prepare,
+      'function',
       'getPrepare(PreparedCompositeComponent) is a function',
     );
     await prepare({ text: 'foo' });
-    t.assert(
+    assert(
       prepareUsingProps.calledOnce,
       'prepareUsingProps has been called exactly once',
     );
-    t.assert(
-      equal(prepareUsingProps.getCall(0).args, [{ text: 'foo' }]),
+    assert.deepEqual(
+      prepareUsingProps.getCall(0).args,
+      [{ text: 'foo' }],
       'prepareUsingProps has been called with correct arguments',
     );
-    t.assert(
+    assert(
       doAsyncSideEffect.calledOnce,
       'doAsyncSideEffect has been called exactly once',
     );
-    t.assert(
-      equal(doAsyncSideEffect.getCall(0).args, ['foo']),
+    assert.deepEqual(
+      doAsyncSideEffect.getCall(0).args,
+      ['foo'],
       'doAsyncSideEffect has been called with correct arguments',
     );
     const html = renderToStaticMarkup(
       <PreparedCompositeComponent text="foo" />,
     );
-    t.assert(html === '<div>foo</div>', 'renders with correct html');
+    assert.equal(html, '<div>foo</div>', 'renders with correct html');
   });
 
   it('prepared Arrow Component', async () => {
@@ -128,39 +134,42 @@ describe('prepared', () => {
     const PreparedCompositeComponent = prepared(prepareUsingProps)(
       OriginalArrowComponent,
     );
-    t.assert(
+    assert(
       !isPrepared(OriginalArrowComponent),
       'OriginalComponent is not prepared',
     );
-    t.assert(
+    assert(
       isPrepared(PreparedCompositeComponent),
       'PreparedComponent is prepared',
     );
     const prepare = getPrepare(PreparedCompositeComponent);
-    t.assert(
-      typeof prepare === 'function',
+    assert.equal(
+      typeof prepare,
+      'function',
       'getPrepare(PreparedCompositeComponent) is a function',
     );
     await prepare({ text: 'foo' });
-    t.assert(
+    assert(
       prepareUsingProps.calledOnce,
       'prepareUsingProps has been called exactly once',
     );
-    t.assert(
-      equal(prepareUsingProps.getCall(0).args, [{ text: 'foo' }]),
+    assert.deepEqual(
+      prepareUsingProps.getCall(0).args,
+      [{ text: 'foo' }],
       'prepareUsingProps has been called with correct arguments',
     );
-    t.assert(
+    assert(
       doAsyncSideEffect.calledOnce,
       'doAsyncSideEffect has been called exactly once',
     );
-    t.assert(
-      equal(doAsyncSideEffect.getCall(0).args, ['foo']),
+    assert.deepEqual(
+      doAsyncSideEffect.getCall(0).args,
+      ['foo'],
       'doAsyncSideEffect has been called with correct arguments',
     );
     const html = renderToStaticMarkup(
       <PreparedCompositeComponent text="foo" />,
     );
-    t.assert(html === '<div>foo</div>', 'renders with correct html');
+    assert.equal(html, '<div>foo</div>', 'renders with correct html');
   });
 });

--- a/src/tests/prepared.spec.js
+++ b/src/tests/prepared.spec.js
@@ -1,7 +1,6 @@
-import assert from 'assert/strict';
-
-const { describe, it } = global;
+const { describe, it, beforeEach } = global;
 import sinon from 'sinon';
+import assert from 'assert/strict';
 import React, { Component, PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { renderToStaticMarkup } from 'react-dom/server';
@@ -32,144 +31,72 @@ describe('prepared', () => {
     text: PropTypes.string,
   };
 
-  it('prepared Composite Component', async () => {
-    const doAsyncSideEffect = sinon.spy(async () => {});
-    const prepareUsingProps = sinon.spy(async ({ text }) => {
+  let doAsyncSideEffect;
+  let prepareUsingProps;
+
+  beforeEach(() => {
+    doAsyncSideEffect = sinon.spy(async () => {});
+    prepareUsingProps = sinon.spy(async ({ text }) => {
       await doAsyncSideEffect(text);
     });
+  });
+
+  const testComponent = async (OriginalComponent, PreparedComponent) => {
+    assert(!isPrepared(OriginalComponent), 'OriginalComponent is not prepared');
+    assert(isPrepared(PreparedComponent), 'PreparedComponent is prepared');
+    const prepare = getPrepare(PreparedComponent);
+    assert.equal(
+      typeof prepare,
+      'function',
+      'getPrepare(PreparedCompositeComponent) is a function',
+    );
+    await prepare({ text: 'foo' });
+    assert(
+      prepareUsingProps.calledOnce,
+      'prepareUsingProps has been called exactly once',
+    );
+    assert.deepEqual(
+      prepareUsingProps.getCall(0).args,
+      [{ text: 'foo' }],
+      'prepareUsingProps has been called with correct arguments',
+    );
+    assert(
+      doAsyncSideEffect.calledOnce,
+      'doAsyncSideEffect has been called exactly once',
+    );
+    assert.deepEqual(
+      doAsyncSideEffect.getCall(0).args,
+      ['foo'],
+      'doAsyncSideEffect has been called with correct arguments',
+    );
+    const html = renderToStaticMarkup(<PreparedComponent text="foo" />);
+    assert.equal(html, '<div>foo</div>', 'renders with correct html');
+  };
+
+  it('prepared Composite Component', async () => {
     const PreparedCompositeComponent = prepared(prepareUsingProps, {
       pure: false,
     })(OriginalCompositeComponent);
-    assert(
-      !isPrepared(OriginalCompositeComponent),
-      'OriginalComponent is not prepared',
-    );
-    assert(
-      isPrepared(PreparedCompositeComponent),
-      'PreparedComponent is prepared',
-    );
-    const prepare = getPrepare(PreparedCompositeComponent);
-    assert.equal(
-      typeof prepare,
-      'function',
-      'getPrepare(PreparedCompositeComponent) is a function',
-    );
-    await prepare({ text: 'foo' });
-    assert(
-      prepareUsingProps.calledOnce,
-      'prepareUsingProps has been called exactly once',
-    );
-    assert.deepEqual(
-      prepareUsingProps.getCall(0).args,
-      [{ text: 'foo' }],
-      'prepareUsingProps has been called with correct arguments',
-    );
-    assert(
-      doAsyncSideEffect.calledOnce,
-      'doAsyncSideEffect has been called exactly once',
-    );
-    assert.deepEqual(
-      doAsyncSideEffect.getCall(0).args,
-      ['foo'],
-      'doAsyncSideEffect has been called with correct arguments',
-    );
-    const html = renderToStaticMarkup(
-      <PreparedCompositeComponent text="foo" />,
-    );
-    assert.equal(html, '<div>foo</div>', 'renders with correct html');
+
+    await testComponent(OriginalCompositeComponent, PreparedCompositeComponent);
   });
 
   it('prepared Composite Pure Component', async () => {
-    const doAsyncSideEffect = sinon.spy(async () => {});
-    const prepareUsingProps = sinon.spy(async ({ text }) => {
-      await doAsyncSideEffect(text);
-    });
     const PreparedCompositeComponent = prepared(prepareUsingProps)(
       OriginalCompositePureComponent,
     );
-    assert(
-      !isPrepared(OriginalCompositePureComponent),
-      'OriginalComponent is not prepared',
+
+    await testComponent(
+      OriginalCompositePureComponent,
+      PreparedCompositeComponent,
     );
-    assert(
-      isPrepared(PreparedCompositeComponent),
-      'PreparedComponent is prepared',
-    );
-    const prepare = getPrepare(PreparedCompositeComponent);
-    assert.equal(
-      typeof prepare,
-      'function',
-      'getPrepare(PreparedCompositeComponent) is a function',
-    );
-    await prepare({ text: 'foo' });
-    assert(
-      prepareUsingProps.calledOnce,
-      'prepareUsingProps has been called exactly once',
-    );
-    assert.deepEqual(
-      prepareUsingProps.getCall(0).args,
-      [{ text: 'foo' }],
-      'prepareUsingProps has been called with correct arguments',
-    );
-    assert(
-      doAsyncSideEffect.calledOnce,
-      'doAsyncSideEffect has been called exactly once',
-    );
-    assert.deepEqual(
-      doAsyncSideEffect.getCall(0).args,
-      ['foo'],
-      'doAsyncSideEffect has been called with correct arguments',
-    );
-    const html = renderToStaticMarkup(
-      <PreparedCompositeComponent text="foo" />,
-    );
-    assert.equal(html, '<div>foo</div>', 'renders with correct html');
   });
 
   it('prepared Arrow Component', async () => {
-    const doAsyncSideEffect = sinon.spy(async () => {});
-    const prepareUsingProps = sinon.spy(async ({ text }) => {
-      await doAsyncSideEffect(text);
-    });
     const PreparedCompositeComponent = prepared(prepareUsingProps)(
       OriginalArrowComponent,
     );
-    assert(
-      !isPrepared(OriginalArrowComponent),
-      'OriginalComponent is not prepared',
-    );
-    assert(
-      isPrepared(PreparedCompositeComponent),
-      'PreparedComponent is prepared',
-    );
-    const prepare = getPrepare(PreparedCompositeComponent);
-    assert.equal(
-      typeof prepare,
-      'function',
-      'getPrepare(PreparedCompositeComponent) is a function',
-    );
-    await prepare({ text: 'foo' });
-    assert(
-      prepareUsingProps.calledOnce,
-      'prepareUsingProps has been called exactly once',
-    );
-    assert.deepEqual(
-      prepareUsingProps.getCall(0).args,
-      [{ text: 'foo' }],
-      'prepareUsingProps has been called with correct arguments',
-    );
-    assert(
-      doAsyncSideEffect.calledOnce,
-      'doAsyncSideEffect has been called exactly once',
-    );
-    assert.deepEqual(
-      doAsyncSideEffect.getCall(0).args,
-      ['foo'],
-      'doAsyncSideEffect has been called with correct arguments',
-    );
-    const html = renderToStaticMarkup(
-      <PreparedCompositeComponent text="foo" />,
-    );
-    assert.equal(html, '<div>foo</div>', 'renders with correct html');
+
+    await testComponent(OriginalArrowComponent, PreparedCompositeComponent);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1166,11 +1166,6 @@ array.prototype.flatmap@^1.2.5:
     define-properties "^1.1.3"
     es-abstract "^1.19.0"
 
-available-typed-arrays@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
-  integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
-
 babel-plugin-dynamic-import-node@^2.3.3:
   version "2.3.3"
   resolved "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz"
@@ -1442,27 +1437,6 @@ decamelize@^4.0.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz#aa472d7bf660eb15f3494efd531cab7f2a709837"
   integrity sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==
 
-deep-equal@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-2.0.5.tgz#55cd2fe326d83f9cbf7261ef0e060b3f724c5cb9"
-  integrity sha512-nPiRgmbAtm1a3JsnLCf6/SLfXcjyN5v8L1TXzdCmHrXJ4hx+gW/w1YCcn7z8gJtSiDArZCgYtbao3QqLm/N1Sw==
-  dependencies:
-    call-bind "^1.0.0"
-    es-get-iterator "^1.1.1"
-    get-intrinsic "^1.0.1"
-    is-arguments "^1.0.4"
-    is-date-object "^1.0.2"
-    is-regex "^1.1.1"
-    isarray "^2.0.5"
-    object-is "^1.1.4"
-    object-keys "^1.1.1"
-    object.assign "^4.1.2"
-    regexp.prototype.flags "^1.3.0"
-    side-channel "^1.0.3"
-    which-boxed-primitive "^1.0.1"
-    which-collection "^1.0.1"
-    which-typed-array "^1.1.2"
-
 deep-equal@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
@@ -1536,7 +1510,7 @@ encodeurl@^1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
-es-abstract@^1.18.5, es-abstract@^1.19.0, es-abstract@^1.19.1:
+es-abstract@^1.19.0, es-abstract@^1.19.1:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.19.1.tgz#d4885796876916959de78edaa0df456627115ec3"
   integrity sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==
@@ -1561,20 +1535,6 @@ es-abstract@^1.18.5, es-abstract@^1.19.0, es-abstract@^1.19.1:
     string.prototype.trimend "^1.0.4"
     string.prototype.trimstart "^1.0.4"
     unbox-primitive "^1.0.1"
-
-es-get-iterator@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/es-get-iterator/-/es-get-iterator-1.1.2.tgz#9234c54aba713486d7ebde0220864af5e2b283f7"
-  integrity sha512-+DTO8GYwbMCwbywjimwZMHp8AuYXOS2JZFWoi2AlPOS3ebnII9w/NLpNZtA7A0YLaVDw+O7KFCeoIV7OPvM7hQ==
-  dependencies:
-    call-bind "^1.0.2"
-    get-intrinsic "^1.1.0"
-    has-symbols "^1.0.1"
-    is-arguments "^1.1.0"
-    is-map "^2.0.2"
-    is-set "^2.0.2"
-    is-string "^1.0.5"
-    isarray "^2.0.5"
 
 es-to-primitive@^1.2.1:
   version "1.2.1"
@@ -1822,11 +1782,6 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.5.tgz#76c8584f4fc843db64702a6bd04ab7a8bd666da3"
   integrity sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
 
-foreach@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
-  integrity sha1-C+4AUBiusmDQo6865ljdATbsG5k=
-
 fresh@~0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
@@ -1866,7 +1821,7 @@ get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-intrinsic@^1.0.1, get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
+get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
   integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
@@ -2035,14 +1990,6 @@ invariant@^2.2.4:
   dependencies:
     loose-envify "^1.0.0"
 
-is-arguments@^1.0.4, is-arguments@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.1.tgz#15b3f88fda01f2a97fec84ca761a560f123efa9b"
-  integrity sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==
-  dependencies:
-    call-bind "^1.0.2"
-    has-tostringtag "^1.0.0"
-
 is-bigint@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-bigint/-/is-bigint-1.0.4.tgz#08147a1875bc2b32005d41ccd8291dffc6691df3"
@@ -2081,13 +2028,6 @@ is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
 
-is-date-object@^1.0.2:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.5.tgz#0841d5536e724c25597bf6ea62e1bd38298df31f"
-  integrity sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==
-  dependencies:
-    has-tostringtag "^1.0.0"
-
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
@@ -2111,11 +2051,6 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
-
-is-map@^2.0.1, is-map@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.2.tgz#00922db8c9bf73e81b7a335827bc2a43f2b91127"
-  integrity sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==
 
 is-negative-zero@^2.0.1:
   version "2.0.2"
@@ -2146,18 +2081,13 @@ is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
-is-regex@^1.1.1, is-regex@^1.1.4:
+is-regex@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"
   integrity sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==
   dependencies:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
-
-is-set@^2.0.1, is-set@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/is-set/-/is-set-2.0.2.tgz#90755fa4c2562dc1c5d4024760d6119b94ca18ec"
-  integrity sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==
 
 is-shared-array-buffer@^1.0.1:
   version "1.0.2"
@@ -2180,26 +2110,10 @@ is-symbol@^1.0.2, is-symbol@^1.0.3:
   dependencies:
     has-symbols "^1.0.2"
 
-is-typed-array@^1.1.7:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.8.tgz#cbaa6585dc7db43318bc5b89523ea384a6f65e79"
-  integrity sha512-HqH41TNZq2fgtGT8WHVFVJhBVGuY3AnP3Q36K8JKXUxSxRgk/d+7NjmwG2vo2mYmXK8UYZKu0qH8bVP5gEisjA==
-  dependencies:
-    available-typed-arrays "^1.0.5"
-    call-bind "^1.0.2"
-    es-abstract "^1.18.5"
-    foreach "^2.0.5"
-    has-tostringtag "^1.0.0"
-
 is-unicode-supported@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
-
-is-weakmap@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/is-weakmap/-/is-weakmap-2.0.1.tgz#5008b59bdc43b698201d18f62b37b2ca243e8cf2"
-  integrity sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==
 
 is-weakref@^1.0.1:
   version "1.0.2"
@@ -2208,22 +2122,9 @@ is-weakref@^1.0.1:
   dependencies:
     call-bind "^1.0.2"
 
-is-weakset@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/is-weakset/-/is-weakset-2.0.2.tgz#4569d67a747a1ce5a994dfd4ef6dcea76e7c0a1d"
-  integrity sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==
-  dependencies:
-    call-bind "^1.0.2"
-    get-intrinsic "^1.1.1"
-
 isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
-
-isarray@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
-  integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -2519,14 +2420,6 @@ object-inspect@^1.11.0, object-inspect@^1.9.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.0.tgz#6e2c120e868fd1fd18cb4f18c31741d0d6e776f0"
   integrity sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==
-
-object-is@^1.1.4:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.5.tgz#b9deeaa5fc7f1846a0faecdceec138e5778f53ac"
-  integrity sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==
-  dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.1.3"
 
 object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
@@ -2841,7 +2734,7 @@ regenerator-transform@^0.14.2:
   dependencies:
     "@babel/runtime" "^7.8.4"
 
-regexp.prototype.flags@^1.3.0, regexp.prototype.flags@^1.4.1:
+regexp.prototype.flags@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.4.1.tgz#b3f4c0059af9e47eca9f3f660e51d81307e72307"
   integrity sha512-pMR7hBVUUGI7PMA37m2ofIdQCsomVnas+Jn5UPGAHQ+/LlwKm/aTLJHdasmHRzlfeZwHiAOaRSo2rbBDm3nNUQ==
@@ -2976,7 +2869,7 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-side-channel@^1.0.3, side-channel@^1.0.4:
+side-channel@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
   integrity sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
@@ -3101,10 +2994,6 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-tcomb@^3.2.15:
-  version "3.2.20"
-  resolved "https://registry.yarnpkg.com/tcomb/-/tcomb-3.2.20.tgz#823e689dcf3518d82c4b6c890a822aa6916692cd"
-
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -3224,7 +3113,7 @@ whatwg-url@^5.0.0:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"
 
-which-boxed-primitive@^1.0.1, which-boxed-primitive@^1.0.2:
+which-boxed-primitive@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz#13757bc89b209b049fe5d86430e21cf40a89a8e6"
   integrity sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==
@@ -3234,28 +3123,6 @@ which-boxed-primitive@^1.0.1, which-boxed-primitive@^1.0.2:
     is-number-object "^1.0.4"
     is-string "^1.0.5"
     is-symbol "^1.0.3"
-
-which-collection@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/which-collection/-/which-collection-1.0.1.tgz#70eab71ebbbd2aefaf32f917082fc62cdcb70906"
-  integrity sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==
-  dependencies:
-    is-map "^2.0.1"
-    is-set "^2.0.1"
-    is-weakmap "^2.0.1"
-    is-weakset "^2.0.1"
-
-which-typed-array@^1.1.2:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.7.tgz#2761799b9a22d4b8660b3c1b40abaa7739691793"
-  integrity sha512-vjxaB4nfDqwKI0ws7wZpxIlde1XrLX5uB0ZjpfshgmapJMD7jJWhZI+yToJTqaFByF0eNBcYxbjmCzoRP7CfEw==
-  dependencies:
-    available-typed-arrays "^1.0.5"
-    call-bind "^1.0.2"
-    es-abstract "^1.18.5"
-    foreach "^2.0.5"
-    has-tostringtag "^1.0.0"
-    is-typed-array "^1.1.7"
 
 which@2.0.2, which@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
All the tests were using a library called `tcomb` for assertions. This seems to be a type checking library (?), so not really sure why it was used. It worked fine though, so it was completely unneccessary to replace it. But I did, and replaced it with built-in node asserts. This also removed the need for `deep-equals`, as this functionality is built into node assert. 

I also refactored a test to avoid duplicated code.