### PR TITLE
Support UNSAFE_componentDidMount()

### DIFF
--- a/src/prepare.js
+++ b/src/prepare.js
@@ -35,6 +35,10 @@ function createCompositeElementInstance(
   if (instance.componentWillMount) {
     instance.componentWillMount();
   }
+
+  if (instance.UNSAFE_componentWillMount) {
+    instance.UNSAFE_componentWillMount();
+  }
   return instance;
 }
 

--- a/src/tests/prepare.spec.js
+++ b/src/tests/prepare.spec.js
@@ -66,6 +66,34 @@ describe('prepare', () => {
     await prepare(<MessageBox />);
   });
 
+  it('supports state updates inside UNSAFE_componentWillMount', async () => {
+    class MessageBox extends React.Component {
+      constructor(props) {
+        super(props);
+        this.state = {
+          message: 'Hello',
+        };
+      }
+
+      UNSAFE_componentWillMount() {
+        this.setState({ message: 'Updated message' });
+      }
+
+      render() {
+        assert.deepEqual(
+          this.state,
+          { message: 'Updated message' },
+          'updates state on instance',
+        );
+        return null;
+      }
+    }
+
+    renderToStaticMarkup(<MessageBox />);
+
+    await prepare(<MessageBox />);
+  });
+
   it('Should throw exception', async () => {
     const doAsyncSideEffect = sinon.spy(async () => {
       throw new Error('Err');


### PR DESCRIPTION
This is deprecated and should not be used, but as we already have support for componentDidMount() we might as well keep supporting it as UNSAFE_componentDidMount() (renamed in react 17).