### PR TITLE
Fix some bugs

### DIFF
--- a/src/prepare.js
+++ b/src/prepare.js
@@ -85,7 +85,7 @@ async function prepareElement(element, errorHandler, context) {
     case ELEMENT_TYPE.CONTEXT_PROVIDER: {
       const _providers = new Map(context._providers);
       _providers.set(element.type._context.Provider, element.props);
-      return [element.props.children, { ...context, _providers }];
+      return [element.props.children, { _providers }];
     }
     case ELEMENT_TYPE.CONTEXT_CONSUMER: {
       const value = getContextValue(context, element.type._context);
@@ -97,7 +97,11 @@ async function prepareElement(element, errorHandler, context) {
       return [element.type.render(element.props, element.ref), context];
     }
     case ELEMENT_TYPE.MEMO: {
-      return prepareElement({ ...element, type: element.type.type });
+      return prepareElement(
+        { ...element, type: element.type.type },
+        errorHandler,
+        context,
+      );
     }
     case ELEMENT_TYPE.FUNCTION_COMPONENT: {
       setDispatcherContext(context);

--- a/src/utils/dispatcher.js
+++ b/src/utils/dispatcher.js
@@ -21,7 +21,10 @@ const dispatcher = {
     noOp,
   ],
   useMemo: (computeFunction) => computeFunction(),
-  useCallback: (callbackFunction) => () => callbackFunction(),
+  useCallback:
+    (callbackFunction) =>
+    (...args) =>
+      callbackFunction(...args),
   useRef: (initial) => ({ current: initial }),
   useImperativeHandle: noOp,
   useLayoutEffect: noOp,


### PR DESCRIPTION
I found a couple of small bugs that snuck into the new release.

1. Memo didn't pass context to children in `prepare`
2. `useCallback` didn't pass arguments from callback to the function. (`slate-editor` relies on this for some reason)