### PR TITLE
Fix eslint for typescript files

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,14 +18,60 @@
     "ecmaVersion": "latest",
     "sourceType": "module"
   },
-  "plugins": [ "react", "@typescript-eslint"],
+  "overrides": [
+    {
+      "files": ["src/tests/*.js"],
+      "extends": [
+        "eslint:recommended",
+        "plugin:react/recommended"
+      ],
+      "rules": {
+        "@typescript-eslint/no-var-requires": "off",
+        "@typescript-eslint/explicit-function-return-type": "off",
+        "@typescript-eslint/no-empty-function": "off",
+        "react/display-name": "off"
+      }
+    }
+  ],
+  "rules": {
+    "curly": ["error", "all"],
+    "camelcase": [
+      "warn",
+      {
+        "properties": "never"
+      }
+    ],
+    "no-use-before-define": [
+      "warn",
+      { "functions": false, "variables": false }
+    ],
+    "@typescript-eslint/explicit-function-return-type": [
+      "warn",
+      {
+        "allowTypedFunctionExpressions": true,
+        "allowExpressions": true
+      }
+    ],
+    "@typescript-eslint/no-explicit-any": [
+      "warn",
+      {
+        "fixToUnknown": true
+      }
+    ],
+    "@typescript-eslint/explicit-member-accessibility": [
+      "warn",
+      {
+        "accessibility": "no-public"
+      }
+    ],
+    "@typescript-eslint/no-use-before-define": [
+      "warn",
+      { "functions": false, "variables": false }
+    ]
+  },
   "settings": {
     "react": {
       "version": "detect"
     }
-  },
-  "rules": {
-    "react/display-name": "off",
-    "@typescript-eslint/no-empty-function": "off"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "lint": "yarn lint:eslint && yarn lint:prettier",
-    "lint:eslint": "eslint src/**/*.js",
+    "lint:eslint": "eslint src/**/*.{js,ts,tsx}",
     "lint:prettier": "prettier '**/*.{js,css,md,ts,tsx}' --check",
     "build": "vite build && yarn build:types",
     "build:types": "tsc -d --emitDeclarationOnly",

--- a/src/prepare.ts
+++ b/src/prepare.ts
@@ -49,7 +49,7 @@ const updater = {
 function createCompositeElementInstance<P>(
   { type: CompositeComponent, props }: ClassicElement<P>,
   context: PrepareContext,
-) {
+): ClassComponentInstance<P> {
   const instance: ClassComponentInstance<P> = new CompositeComponent(
     props,
     context,

--- a/src/prepared.tsx
+++ b/src/prepared.tsx
@@ -1,4 +1,9 @@
-import React, { PureComponent, Component, ComponentType } from 'react';
+import React, {
+  PureComponent,
+  Component,
+  ComponentType,
+  ReactNode,
+} from 'react';
 
 import { __REACT_PREPARE__ } from './constants';
 import {
@@ -39,13 +44,13 @@ const prepared =
       // Placeholder to allow referencing this.context in lifecycle methods
       static contextTypes = contextTypes;
 
-      componentDidMount() {
+      componentDidMount(): void {
         if (componentDidMount) {
           prepare(this.props, this.context as C);
         }
       }
 
-      componentWillReceiveProps(nextProps: Readonly<P>, nextContext: C) {
+      componentWillReceiveProps(nextProps: Readonly<P>, nextContext: C): void {
         if (
           typeof componentWillReceiveProps === 'function'
             ? componentWillReceiveProps(
@@ -60,7 +65,7 @@ const prepared =
         }
       }
 
-      render() {
+      render(): ReactNode {
         return <OriginalComponent {...this.props} />;
       }
 

--- a/src/utils/dispatcher.ts
+++ b/src/utils/dispatcher.ts
@@ -2,7 +2,6 @@ import getContextValue from './getContextValue';
 import { __REACT_PREPARE__ } from '../constants';
 import React, {
   Context,
-  Dispatch,
   DispatchWithoutAction,
   Reducer,
   ReducerState,

--- a/src/utils/dispatcher.ts
+++ b/src/utils/dispatcher.ts
@@ -19,7 +19,9 @@ type Dispatcher = ReactDispatcher & {
 const ReactInternals = (React as ReactWithInternals)
   .__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
 
-const noOp = () => {};
+const noOp = (): void => {
+  // do nothing
+};
 
 function readContext<T>(this: Dispatcher, context: Context<T>): T {
   return getContextValue(this[__REACT_PREPARE__].context, context);
@@ -60,11 +62,13 @@ const dispatcher: Dispatcher = {
   },
 };
 
-export const setDispatcherContext = (context: PrepareContext) =>
-  (dispatcher[__REACT_PREPARE__].context = context);
+export const setDispatcherContext = (context: PrepareContext): void => {
+  dispatcher[__REACT_PREPARE__].context = context;
+};
 
-export const registerDispatcher = () =>
-  (ReactInternals.ReactCurrentDispatcher.current = dispatcher);
+export const registerDispatcher = (): void => {
+  ReactInternals.ReactCurrentDispatcher.current = dispatcher;
+};
 
-export const dispatcherIsRegistered = () =>
+export const dispatcherIsRegistered = (): boolean =>
   ReactInternals.ReactCurrentDispatcher.current === dispatcher;

--- a/src/utils/getElementType.ts
+++ b/src/utils/getElementType.ts
@@ -21,7 +21,7 @@ function isReactElement(element: ReactNode): element is ReactElement {
   return !!element && typeof element === 'object';
 }
 
-export default function getElementType(element: ReactNode) {
+export default function getElementType(element: ReactNode): ELEMENT_TYPE {
   if (isTextNode(element)) {
     return ELEMENT_TYPE.TEXT_NODE;
   } else if (!isReactElement(element)) {


### PR DESCRIPTION
When i did the typescript conversion i forgot to add `.ts` extension to the eslint command 😬. So it didn't run on any typescript files. I also copied over some rule config from `lego-editor` which enables more rules for typescript files.