### PR TITLE
Add usePreparedEffect hook and withPreparedEffect higher order component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,48 @@
-## react-prepare
+# react-prepare
 
-`react-prepare` allows you to have you deeply nested components with asynchronous dependencies, and have everything just work with server-side rendering.
+`react-prepare` is a package that allows you to easily await asynchronous data requirements defined in your React components before server-side rendering.
 
 The typical use-case is when a deeply-nested component needs to have a resource fetched from a remote HTTP server, such as GraphQL or REST API. Since `renderToString` is synchronous, when you call it on your app, this component won't render correctly.
 
-One solution is to have a central router at the root of your application that knows exactly what data needs to be fetched before rendering. But this solution doesn't fit the component-based architecture of a typical React app. You want to declare data dependencies at the component level, much like your declare your props.
+One solution is to have a central router at the root of your application that knows exactly what data needs to be fetched before rendering. But this solution doesn't fit the component-based architecture of a typical React app. You want to declare data dependencies at the component level.
 
 This is exactly what `react-prepare` does: it allows you to declare asynchronous dependencies at the component level, and make them work fine with server-side rendering as well as client-side rendering.
 
-`react-prepare` is agnostic and can be used vanilla, but it comes with a tiny helper that makes it extremely easy to use along `redux` and `react-redux` (see examples below).
-
-#### Example with `react-redux`
+## Example with `react-redux`
 
 Let's assume you have defined an async action creator `fetchTodoItems(userName)` which performs HTTP request to your server to retrieve the todo items for a given user and stores the result in your redux state.
 
 Your `TodoList` component definition would look like this:
 
 ```js
-import { dispatched } from 'react-prepare';
-import { connect } from 'react-redux';
+import { usePreparedEffect } from 'react-prepare';
+import { useDispatch, useSelector } from 'react-redux';
 import { compose } from 'redux';
 
 import { fetchTodoItems } from './actions';
 
-const enhance = compose(
-  dispatched(({ userName }, dispatch) => dispatch(fetchTodoItems(userName))),
-  connect(({ todoItems }) => ({ items: todoItems }),
-);
+const TodoList = ({ userName }) => {
+  const dispatch = useDispatch();
+  const items = useSelector(({ todoItems }) => todoItems);
 
-const TodoList = ({ items }) => <ul>{items.map((item, key) =>
-  <li key={key}>{item}</li>
-</ul>}</ul>;
+  usePreparedEffect(
+    'fetchTodoItems',
+    () => {
+      dispatch(fetchTodoItems(userName));
+    },
+    [userName],
+  );
 
-export default enhance(TodoList);
+  return (
+    <ul>
+      {items.map((item, key) => (
+        <li key={key}>{item}</li>
+      ))}
+    </ul>
+  );
+};
+
+export default TodoList;
 ```
 
 And your server-side rendering code would look like this:
@@ -61,7 +71,7 @@ async function serverSideRender(userName) {
 }
 ```
 
-Your client could re-use the data fetched during server-side rendering directly, eg. assuming your injected it in `window.__APP_STATE__`:
+Your client should re-use the data fetched during server-side rendering directly, eg. assuming your injected it in `window.__APP_STATE__`:
 
 ```js
 const store = createStore(reducer, JSON.parse(window.__APP_STATE__));
@@ -73,11 +83,57 @@ render(
 );
 ```
 
-**For a complete example of a fully-functional app using `react-prepare` in conjunction with `redux`, see the [react-prepare-todo](https://github.com/elierotenberg/react-prepare-todo) repository.**
+## API
 
-### API
+### `usePreparedEffect(identifier: string, sideEffect: async () => Promise<void>, deps, opts)`
 
-#### `dispatched(sideEffect: async(props, dispatch), opts)(Component)`
+Works like `useEffect` except that effects will be run on the server instead of the client the first time, when server-side rendering in enabled.
+
+#### identifier
+
+A string that uniquely identifies the effect. It is used to keep track of what effects have been run on the server.
+
+#### sideEffect
+
+An async function that performs the side effect. It should return a promise that will be awaited before server-side rendering.
+
+#### deps
+
+An array of dependencies. If any of the dependencies change, the effect will be run again. Just like `useEffect` it uses shallow, strict equality (===).
+
+Like a normal `useEffect`, the effect will rerun on every render if nothing is passed to `deps`.
+
+#### opts
+
+An optional configuration object that can contain the following properties:
+
+- `opts.runSync` (default: `false`):
+  - `true`: When running `prepare`, the `sideEffect`-promise will be awaited before traversing further down the tree. (because of limitations in the current implementation, effects in the same component will be run in parallel)
+  - `false`: When running `prepare` the promise will be awaited in parallell with all other prepared effects after the tree has been traversed.
+
+### `withPreparedEffect(identifier: string, sideEffect: async (props) => Promise<void>, depsFn: (props) => [], opts)(Component)`
+
+Higher order component wrapper for `usePreparedEffect`, provided for compatibility with class components. Wraps `Component` with a component that contains a `usePreparedEffect` hook that calls `sideEffect` with the component's props.
+
+#### identifier
+
+A string that uniquely identifies the effect. It is used to keep track of what effects have been run on the server.
+
+#### sideEffect
+
+An async function that performs the side effect. It should return a promise that will be awaited before server-side rendering.
+
+#### depsFn
+
+A function that takes the component's props and returns an array of dependencies. If any of the dependencies change, the effect will be run again. Just like `useEffect` it uses shallow, strict equality (===).
+
+If no `depsFn` is provided, an empty dependency-array will be used, and the sideEffect will never re-run (as opposed to `usePreparedEffect`, which would run sideEffect on every render).
+
+#### opts
+
+Available `opts` are the same as in `usePreparedEffect`.
+
+### `dispatched(sideEffect: async(props, dispatch), opts)(Component)`
 
 Helper to use `prepared` more simply if your side effects consists mostly of dispatching redux actions.
 
@@ -101,7 +157,7 @@ The decorated component will have the following behavior:
 
 `opts` is an optional configuration object passed directly to the underlying `prepared` decorator (see below).
 
-#### `prepared(sideEffect: async(props, context), opts)(Component)`
+### `prepared(sideEffect: async(props, context), opts)(Component)`
 
 Decorates `Component` so that when `prepare` is called, `sideEffect` is called (and awaited) before continuing the rendering traversal.
 
@@ -112,12 +168,12 @@ Available `opts` is an optional configuration object:
 - `opts.componentWillReceiveProps` (default: `true`): on the client, `sideEffect` is called again whenever the component receive props.
 - `opts.awaitOnSsr` (default: `true`): on the server, should `prepare` await `sideEffect` before traversing further down the tree. When `false` the promise will be awaited before `prepare` returns.
 
-#### `async prepare(Element, ?opts)`
+### `async prepare(Element, ?opts) => string`
 
-Recursively traverses the element rendering tree and awaits the side effects of components decorated with `prepared` (or `dispatched`).
-It should be used (and `await`-ed) _before_ calling `renderToString` on the server. If any of the side effects throws, `prepare` will also throw.
+Recursively traverses the element rendering tree, collecting all promises from `usePreparedEffect`, `withPreparedEffect`, `prepared` (or `dispatched`) and awaits them as defined (either after traversing the tree, or before traversing further with `awaitOnSsr` or `runSync`).
+It should be used (and `await`-ed) _before_ calling `renderToString` on the server. If any of the side effects throws, and an `errorHandler` has not been provided, `prepare` will also throw.
 
-`opts` is an optional configuration object.
+The return value is a string containing js-code to set a key on the `window` object, that will be used in the client-side rendering to avoid re-running any side effects.
 
 Available `opts` is an optional configuration object:
 
@@ -128,3 +184,4 @@ Available `opts` is an optional configuration object:
 
 `react-prepare` tries hard to avoid object keys conflicts, but since React isn't very friendly with `Symbol`, it uses a special key for its internal use.
 The single polluted key in the components key namespace is `@__REACT_PREPARE__@`, which shouldn't be an issue.
+This key is also used in the `window` object to store what side-effects are prepared.

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "author": "Elie Rotenberg <elie@rotenberg.io>",
   "license": "MIT",
   "devDependencies": {
+    "@testing-library/react": "^13.3.0",
     "@types/assert": "^1.5.6",
     "@types/mocha": "^9.1.1",
     "@types/node": "^18.0.3",
@@ -40,6 +41,7 @@
     "eslint": "^8.12.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-react": "^7.29.4",
+    "jsdom": "^20.0.0",
     "koa": "^2.13.4",
     "node-fetch": "^2.6.7",
     "prettier": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Prepare you app state for async server-side rendering and more!",
   "type": "module",
   "main": "./dist/react-prepare.umd.cjs",
-  "module": "./dist/react-prepare.mjs",
+  "module": "./dist/react-prepare.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist/**/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webkom/react-prepare",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Prepare you app state for async server-side rendering and more!",
   "type": "module",
   "main": "./dist/react-prepare.umd.cjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
 import usePreparedEffect from './usePreparedEffect';
+import withPreparedEffect from './withPreparedEffect';
 import dispatched from './dispatched';
 import prepare from './prepare';
 import prepared from './prepared';
 
-export { dispatched, prepare, prepared, usePreparedEffect };
+export { dispatched, prepare, prepared, usePreparedEffect, withPreparedEffect };
 
 export default prepare;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
+import usePreparedEffect from './usePreparedEffect';
 import dispatched from './dispatched';
 import prepare from './prepare';
 import prepared from './prepared';
 
-export { dispatched, prepare, prepared };
+export { dispatched, prepare, prepared, usePreparedEffect };
 
 export default prepare;

--- a/src/prepare.ts
+++ b/src/prepare.ts
@@ -13,6 +13,7 @@ import getContextValue from './utils/getContextValue';
 import {
   createDispatcher,
   Dispatcher,
+  popSyncHookPromises,
   popHookPromises,
   popPreparedHookIdentifiers,
   registerDispatcher,
@@ -162,7 +163,9 @@ async function prepareElement(
       const functionElement = element as FunctionComponentElement<unknown>;
       setDispatcherContext(dispatcher, context);
       registerDispatcher(dispatcher);
-      return [functionElement.type(functionElement.props), context];
+      const children: ReactNode = functionElement.type(functionElement.props);
+      await Promise.all(popSyncHookPromises(dispatcher));
+      return [children, context];
     }
     case ELEMENT_TYPE.CLASS_COMPONENT: {
       return prepareCompositeElement(

--- a/src/tests/prepare.spec.jsx
+++ b/src/tests/prepare.spec.jsx
@@ -22,7 +22,7 @@ import PropTypes from 'prop-types';
 import { renderToStaticMarkup } from 'react-dom/server';
 import prepared from '../prepared';
 import prepare from '../prepare';
-import { usePreparedEffect } from '../index';
+import { usePreparedEffect, withPreparedEffect } from '../index';
 
 describe('prepare', () => {
   it('sets instance properties', async () => {
@@ -130,7 +130,7 @@ describe('prepare', () => {
       );
     } catch (err) {
       assert.equal(err.message, 'Err', 'Should throw the correct error');
-      assert(doAsyncSideEffect.calledOnce, 'Should be called once times');
+      assert(doAsyncSideEffect.calledOnce, 'Should be called one time');
       return;
     }
     assert.fail('It should throw');
@@ -146,6 +146,61 @@ describe('prepare', () => {
     };
 
     const App = prepared(prepareUsingProps)(({ text, children }) => (
+      <div>
+        {text} <div>{children ? children : null}</div>
+      </div>
+    ));
+    await prepare(
+      <App text="foo">
+        <App text="foo" />
+        <App text="foo" />
+      </App>,
+      { errorHandler: (e) => e },
+    );
+    assert(doAsyncSideEffect.calledThrice, 'Should be called 3 times');
+  });
+
+  it('Should throw exception using withPreparedEffect', async () => {
+    const doAsyncSideEffect = sinon.spy(async () => {
+      throw new Error('Err');
+    });
+    const prepareUsingProps = async ({ text }) => {
+      await doAsyncSideEffect(text);
+    };
+    const App = withPreparedEffect(
+      'effect',
+      prepareUsingProps,
+    )(({ text }) => <div>{text}</div>);
+    try {
+      await prepare(
+        <App text="foo">
+          <App text="foo" />
+          <App text="foo" />
+          <App text="foo" />
+          <App text="foo" />
+        </App>,
+      );
+    } catch (err) {
+      assert.equal(err.message, 'Err', 'Should throw the correct error');
+      assert(doAsyncSideEffect.calledOnce, 'Should be called one time');
+      return;
+    }
+    assert.fail('It should throw');
+  });
+
+  it("Should be possible to don't throw exception using withPreparedEffect", async () => {
+    const doAsyncSideEffect = sinon.spy(async () => {
+      throw new Error('Errooor');
+    });
+
+    const prepareUsingProps = async ({ text }) => {
+      await doAsyncSideEffect(text);
+    };
+
+    const App = withPreparedEffect(
+      'effect',
+      prepareUsingProps,
+    )(({ text, children }) => (
       <div>
         {text} <div>{children ? children : null}</div>
       </div>

--- a/src/tests/usePreparedEffect.spec.jsx
+++ b/src/tests/usePreparedEffect.spec.jsx
@@ -1,0 +1,297 @@
+/* eslint-disable react/prop-types */
+import { describe, it, beforeEach } from 'vitest';
+import React from 'react';
+import assert from 'assert/strict';
+import sinon from 'sinon';
+import prepare, { prepared, usePreparedEffect } from '../index';
+import { render } from '@testing-library/react';
+import { __REACT_PREPARE__ } from '../constants';
+
+describe('usePreparedEffect', () => {
+  let doAsyncSideEffect;
+  let prepareFunction;
+
+  beforeEach(() => {
+    window[__REACT_PREPARE__] = undefined;
+    doAsyncSideEffect = sinon.spy(async () => {
+      return;
+    });
+    prepareFunction = sinon.spy(async () => {
+      await doAsyncSideEffect();
+    });
+  });
+
+  it('should run prepare function when prepared', async () => {
+    const Component = () => {
+      usePreparedEffect('effect', prepareFunction);
+
+      return <div></div>;
+    };
+
+    await prepare(<Component />);
+
+    assert(
+      prepareFunction.calledOnce,
+      'prepareFunction has been called exactly once',
+    );
+    assert(
+      doAsyncSideEffect.calledOnce,
+      'async side effect has been called exactly once',
+    );
+  });
+
+  it('should run prepare function on nested components when prepared', async () => {
+    const Component = ({ children }) => {
+      return <div>{children}</div>;
+    };
+
+    const PreparedComponent = prepared(prepareFunction)(Component);
+
+    const PreparedEffectComponent = () => {
+      usePreparedEffect('effect', prepareFunction);
+
+      return <div></div>;
+    };
+
+    await prepare(
+      <Component>
+        <PreparedComponent>
+          <PreparedEffectComponent />
+        </PreparedComponent>
+      </Component>,
+    );
+
+    assert(
+      prepareFunction.calledTwice,
+      'prepareFunction has been called from both PreparedComponent and PreparedEffectComponent',
+    );
+    assert(
+      doAsyncSideEffect.calledTwice,
+      'async side effect has been called from PreparedComponent and PreparedEffectComponent',
+    );
+  });
+
+  it('should run effect after rendering on client-side when NOT prepared', () => {
+    const Component = () => {
+      usePreparedEffect('effect', prepareFunction);
+      return <div />;
+    };
+
+    render(<Component />);
+
+    assert(
+      prepareFunction.calledOnce,
+      'prepareFunction has been called exactly once',
+    );
+  });
+
+  it('should NOT re-run effect on client after being prepared', async () => {
+    const Component = () => {
+      usePreparedEffect('effect', prepareFunction);
+      return <div />;
+    };
+
+    const prepareClientCode = await prepare(<Component />);
+
+    assert(
+      prepareFunction.calledOnce,
+      'prepareFunction has been called exactly once',
+    );
+
+    eval(prepareClientCode);
+
+    render(<Component />);
+
+    assert(
+      prepareFunction.calledOnce,
+      'prepareFunction has been called exactly once',
+    );
+  });
+
+  it('should re-run effect on client after being prepared and dep changed', async () => {
+    const Component = ({ prop }) => {
+      usePreparedEffect('effect', prepareFunction, [prop]);
+      return <div />;
+    };
+
+    const prepareClientCode = await prepare(<Component prop={'a'} />);
+
+    assert(
+      prepareFunction.calledOnce,
+      'prepareFunction has been called exactly once',
+    );
+
+    eval(prepareClientCode);
+
+    const { rerender } = render(<Component prop={'a'} />);
+
+    assert(
+      prepareFunction.calledOnce,
+      'prepareFunction has not been called again',
+    );
+
+    rerender(<Component prop={'b'} />);
+
+    assert(
+      prepareFunction.calledTwice,
+      'prepareFunction has been called once more after prop changed',
+    );
+  });
+
+  it('should NOT re-run effect on client after being prepared if no dep changed', async () => {
+    const Component = ({ prop }) => {
+      usePreparedEffect('effect', prepareFunction, [prop]);
+      return <div />;
+    };
+
+    const prepareClientCode = await prepare(<Component prop={'a'} />);
+
+    assert(
+      prepareFunction.calledOnce,
+      'prepareFunction has been called exactly once',
+    );
+
+    eval(prepareClientCode);
+
+    const { rerender } = render(<Component prop={'a'} />);
+
+    assert(
+      prepareFunction.calledOnce,
+      'prepareFunction has not been called again',
+    );
+
+    rerender(<Component prop={'a'} />);
+
+    assert(
+      prepareFunction.calledOnce,
+      'prepareFunction has still not been called again',
+    );
+  });
+
+  it('should re-run effect after being prepared if component is unmounted and re-mounted', async () => {
+    const Component = ({ prop }) => {
+      usePreparedEffect('effect', prepareFunction, [prop]);
+      return <div />;
+    };
+
+    const prepareClientCode = await prepare(<Component prop={'a'} />);
+
+    assert(
+      prepareFunction.calledOnce,
+      'prepareFunction has been called exactly once',
+    );
+
+    eval(prepareClientCode);
+
+    const { rerender } = render(<Component prop={'a'} />);
+
+    assert(
+      prepareFunction.calledOnce,
+      'prepareFunction has not been called again',
+    );
+
+    // unmount component
+    rerender(<></>);
+
+    // re-mount component
+    rerender(<Component prop={'a'} />);
+
+    assert(
+      prepareFunction.calledTwice,
+      'prepareFunction has been called on re-mount',
+    );
+  });
+
+  it('should run effect on client after other effect is prepared', async () => {
+    const Component = () => {
+      usePreparedEffect('effect', prepareFunction);
+      return <div />;
+    };
+
+    const otherEffectFunction = sinon.spy(async () => {
+      return;
+    });
+
+    const OtherComponent = () => {
+      usePreparedEffect('otherEffect', otherEffectFunction);
+      return <div />;
+    };
+
+    const prepareClientCode = await prepare(<Component />);
+
+    assert(
+      prepareFunction.calledOnce,
+      'prepareFunction has been called exactly once',
+    );
+    assert(
+      otherEffectFunction.notCalled,
+      'otherEffectFunction has not been called',
+    );
+
+    eval(prepareClientCode);
+    render(<OtherComponent />);
+
+    assert(
+      otherEffectFunction.calledOnce,
+      'otherEffectFunction has now been called',
+    );
+  });
+
+  it('should re-run effect when re-rendering with dependency-array undefined', () => {
+    const Component = () => {
+      usePreparedEffect('effect', prepareFunction);
+      return <div />;
+    };
+
+    const { rerender } = render(<Component />);
+
+    rerender(<Component />);
+
+    assert(
+      prepareFunction.calledTwice,
+      'prepareFunction has been called on both renders',
+    );
+  });
+
+  it('should re-run effect when a dependency has changed', () => {
+    const Component = ({ dep }) => {
+      usePreparedEffect('effect', prepareFunction, [dep]);
+      return <div />;
+    };
+
+    const { rerender } = render(<Component dep={1} />);
+
+    assert(
+      prepareFunction.calledOnce,
+      'prepareFunction has been called on initial render',
+    );
+
+    rerender(<Component dep={2} />);
+
+    assert(
+      prepareFunction.calledTwice,
+      'prepareFunction has also been called on re-rerender with changed dependency',
+    );
+  });
+
+  it('should not re-run effect when a dependency stays the same', () => {
+    const Component = ({ dep }) => {
+      usePreparedEffect('effect', prepareFunction, [dep]);
+      return <div />;
+    };
+
+    const { rerender } = render(<Component dep={1} />);
+
+    assert(
+      prepareFunction.calledOnce,
+      'prepareFunction has been called on initial render',
+    );
+
+    rerender(<Component dep={1} />);
+
+    assert(
+      prepareFunction.calledOnce,
+      'prepareFunction has not been called again on re-rerender with same dependency',
+    );
+  });
+});

--- a/src/tests/withPreparedEffect.spec.jsx
+++ b/src/tests/withPreparedEffect.spec.jsx
@@ -1,0 +1,172 @@
+import { describe, it, beforeEach } from 'vitest';
+import sinon from 'sinon';
+import assert from 'assert/strict';
+import React, { Component, PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { prepare, withPreparedEffect } from '../index';
+import { render } from '@testing-library/react';
+
+describe('withPreparedEffect', () => {
+  class OriginalCompositeComponent extends Component {
+    static propTypes = {
+      text: PropTypes.string,
+    };
+    render() {
+      return <div>{this.props.text}</div>;
+    }
+  }
+
+  class OriginalCompositePureComponent extends PureComponent {
+    static propTypes = {
+      text: PropTypes.string,
+    };
+    render() {
+      return <div>{this.props.text}</div>;
+    }
+  }
+
+  const OriginalArrowComponent = ({ text }) => <div>{text}</div>;
+  OriginalArrowComponent.propTypes = {
+    text: PropTypes.string,
+  };
+
+  let doAsyncSideEffect;
+  let prepareUsingProps;
+
+  beforeEach(() => {
+    doAsyncSideEffect = sinon.spy(async () => {});
+    prepareUsingProps = sinon.spy(async ({ text }) => {
+      await doAsyncSideEffect(text);
+    });
+  });
+
+  const testComponent = async (OriginalComponent, PreparedComponent) => {
+    await prepare(<OriginalComponent text="foo" />);
+    assert(
+      prepareUsingProps.notCalled,
+      'prepareUsingProps has not been called yet',
+    );
+
+    await prepare(<PreparedComponent text="foo" />);
+    assert(
+      prepareUsingProps.calledOnce,
+      'prepareUsingProps has been called exactly once',
+    );
+    assert.deepEqual(
+      prepareUsingProps.getCall(0).args,
+      [{ text: 'foo' }],
+      'prepareUsingProps has been called with correct arguments',
+    );
+    assert(
+      doAsyncSideEffect.calledOnce,
+      'doAsyncSideEffect has been called exactly once',
+    );
+    assert.deepEqual(
+      doAsyncSideEffect.getCall(0).args,
+      ['foo'],
+      'doAsyncSideEffect has been called with correct arguments',
+    );
+    const html = renderToStaticMarkup(<PreparedComponent text="foo" />);
+    assert.equal(html, '<div>foo</div>', 'renders with correct html');
+  };
+
+  it('works with Composite Component', async () => {
+    const PreparedCompositeComponent = withPreparedEffect(
+      'effect',
+      prepareUsingProps,
+      (props) => [props.text],
+    )(OriginalCompositeComponent);
+
+    await testComponent(OriginalCompositeComponent, PreparedCompositeComponent);
+  });
+
+  it('works with Composite Pure Component', async () => {
+    const PreparedCompositeComponent = withPreparedEffect(
+      'effect',
+      prepareUsingProps,
+      (props) => [props.text],
+    )(OriginalCompositePureComponent);
+
+    await testComponent(
+      OriginalCompositePureComponent,
+      PreparedCompositeComponent,
+    );
+  });
+
+  it('works with Arrow Component', async () => {
+    const PreparedCompositeComponent = withPreparedEffect(
+      'effect',
+      prepareUsingProps,
+      (props) => [props.text],
+    )(OriginalArrowComponent);
+
+    await testComponent(OriginalArrowComponent, PreparedCompositeComponent);
+  });
+
+  it('reruns effect when dependency changes', async () => {
+    const PreparedComponent = withPreparedEffect(
+      'effect',
+      prepareUsingProps,
+      (props) => [props.text],
+    )(OriginalArrowComponent);
+
+    await prepare(<PreparedComponent text="foo" />);
+
+    assert(
+      prepareUsingProps.calledOnce,
+      'prepareUsingProps was called exactly once when preparing',
+    );
+
+    const element = await render(<PreparedComponent text="foo" />);
+
+    assert(
+      prepareUsingProps.calledTwice,
+      'prepareUsingProps was called once more when rendering',
+    );
+
+    element.rerender(<PreparedComponent text="foo" />);
+
+    assert(
+      prepareUsingProps.calledTwice,
+      'prepareUsingProps was NOT called again when rerendering with same props',
+    );
+
+    element.rerender(<PreparedComponent text="bar" />);
+
+    assert(
+      prepareUsingProps.calledThrice,
+      'prepareUsingProps was called once more when rerendering with different props',
+    );
+  });
+
+  it('does not rerun effect if changed prop is not in deps', async () => {
+    const PreparedComponent = withPreparedEffect(
+      'effect',
+      prepareUsingProps,
+      () => [],
+    )(OriginalArrowComponent);
+
+    await prepare(<PreparedComponent text="foo" />);
+
+    assert(
+      prepareUsingProps.calledOnce,
+      'prepareUsingProps was called exactly once when preparing',
+    );
+
+    const element = await render(<PreparedComponent text="foo" />);
+
+    assert(
+      prepareUsingProps.calledTwice,
+      'prepareUsingProps was called once more when rendering',
+    );
+
+    element.rerender(<PreparedComponent text="bar" />);
+
+    assert(
+      prepareUsingProps.calledTwice,
+      'prepareUsingProps was NOT called again when rerendering with changed props',
+    );
+  });
+});

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,4 +1,4 @@
-import { Component, ComponentType, Provider } from 'react';
+import { Component, ComponentType, EffectCallback, Provider } from 'react';
 import { __REACT_PREPARE__ } from './constants';
 import { Dispatch } from 'redux';
 import PropTypes from 'prop-types';
@@ -55,3 +55,22 @@ export type ClassComponentInstance<P, S = unknown> = Omit<
   };
   getChildContext?: () => PrepareContext;
 };
+
+export type PrepareHookFunction = () => Promise<void>;
+
+export type PrepareHookEffect = EffectCallback & {
+  [__REACT_PREPARE__]: {
+    identifier: string;
+    prepare: PrepareHookFunction;
+  };
+};
+
+// declare the [__REACT_PREPARE__] property on the global Window interface
+// for correct type checking on global context set on ssr
+declare global {
+  interface Window {
+    [__REACT_PREPARE__]?: {
+      preparedEffects: string[];
+    };
+  }
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -62,6 +62,7 @@ export type PrepareHookEffect = EffectCallback & {
   [__REACT_PREPARE__]: {
     identifier: string;
     prepare: PrepareHookFunction;
+    runSync: boolean;
   };
 };
 

--- a/src/usePreparedEffect.ts
+++ b/src/usePreparedEffect.ts
@@ -2,11 +2,16 @@ import { PrepareHookEffect, PrepareHookFunction } from './types';
 import { DependencyList, EffectCallback, useEffect, useRef } from 'react';
 import { __REACT_PREPARE__ } from './constants';
 
+interface Options {
+  runSync?: boolean;
+}
+
 const usePreparedEffect = (
   identifier: string,
   prepareFunction: PrepareHookFunction,
   deps?: DependencyList,
-) => {
+  { runSync = false }: Options = {},
+): void => {
   // keep track of whether it is the initial effect-run or not, as only the first run is affected by server-preparing
   const isInitialRunOnClient = useRef(true);
 
@@ -43,6 +48,7 @@ const usePreparedEffect = (
   (effect as PrepareHookEffect)[__REACT_PREPARE__] = {
     identifier,
     prepare: prepareFunction,
+    runSync,
   };
 
   useEffect(effect, deps);

--- a/src/usePreparedEffect.ts
+++ b/src/usePreparedEffect.ts
@@ -2,7 +2,7 @@ import { PrepareHookEffect, PrepareHookFunction } from './types';
 import { DependencyList, EffectCallback, useEffect, useRef } from 'react';
 import { __REACT_PREPARE__ } from './constants';
 
-interface Options {
+export interface PreparedEffectOptions {
   runSync?: boolean;
 }
 
@@ -10,7 +10,7 @@ const usePreparedEffect = (
   identifier: string,
   prepareFunction: PrepareHookFunction,
   deps?: DependencyList,
-  { runSync = false }: Options = {},
+  { runSync = false }: PreparedEffectOptions = {},
 ): void => {
   // keep track of whether it is the initial effect-run or not, as only the first run is affected by server-preparing
   const isInitialRunOnClient = useRef(true);

--- a/src/usePreparedEffect.ts
+++ b/src/usePreparedEffect.ts
@@ -1,0 +1,51 @@
+import { PrepareHookEffect, PrepareHookFunction } from './types';
+import { DependencyList, EffectCallback, useEffect, useRef } from 'react';
+import { __REACT_PREPARE__ } from './constants';
+
+const usePreparedEffect = (
+  identifier: string,
+  prepareFunction: PrepareHookFunction,
+  deps?: DependencyList,
+) => {
+  // keep track of whether it is the initial effect-run or not, as only the first run is affected by server-preparing
+  const isInitialRunOnClient = useRef(true);
+
+  const effect: EffectCallback = () => {
+    const preparedEffects = window[__REACT_PREPARE__]?.preparedEffects;
+
+    const didRunOnServer = preparedEffects?.includes(identifier);
+
+    // If this is a re-run of the effect on the client, the dependency array must have changed, and we want to run the prepare function again.
+    // We also want to run the prepare function on the client if it was not prepared on the server.
+    const shouldRunEffect = !isInitialRunOnClient.current || !didRunOnServer;
+
+    if (shouldRunEffect) {
+      prepareFunction();
+    }
+
+    isInitialRunOnClient.current = false;
+
+    // remove the effect from the list of prepared effects on cleanup, such that it will be re-run if the component re-mounts.
+    return () => {
+      if (
+        window[__REACT_PREPARE__] &&
+        window[__REACT_PREPARE__].preparedEffects.includes(identifier)
+      ) {
+        window[__REACT_PREPARE__].preparedEffects.splice(
+          window[__REACT_PREPARE__].preparedEffects.indexOf(identifier),
+          1,
+        );
+      }
+    };
+  };
+
+  // Set react-prepare specific properties on the effect function, so that we can identify it as a prepare-hook effect and run the prepare function in the dispatcher.
+  (effect as PrepareHookEffect)[__REACT_PREPARE__] = {
+    identifier,
+    prepare: prepareFunction,
+  };
+
+  useEffect(effect, deps);
+};
+
+export default usePreparedEffect;

--- a/src/utils/dispatcher.ts
+++ b/src/utils/dispatcher.ts
@@ -9,7 +9,7 @@ import React, {
 import { ReactDispatcher, ReactWithInternals } from './reactInternalTypes';
 import { PrepareContext } from '../types';
 
-type Dispatcher = ReactDispatcher & {
+export type Dispatcher = ReactDispatcher & {
   [__REACT_PREPARE__]: {
     context: PrepareContext;
   };
@@ -26,7 +26,7 @@ function readContext<T>(this: Dispatcher, context: Context<T>): T {
   return getContextValue(this[__REACT_PREPARE__].context, context);
 }
 
-const dispatcher: Dispatcher = {
+export const createDispatcher = (): Dispatcher => ({
   readContext: readContext,
   useContext: readContext,
   useEffect: noOp,
@@ -59,15 +59,15 @@ const dispatcher: Dispatcher = {
   [__REACT_PREPARE__]: {
     context: {},
   },
-};
+});
 
-export const setDispatcherContext = (context: PrepareContext): void => {
+export const setDispatcherContext = (
+  dispatcher: Dispatcher,
+  context: PrepareContext,
+): void => {
   dispatcher[__REACT_PREPARE__].context = context;
 };
 
-export const registerDispatcher = (): void => {
+export const registerDispatcher = (dispatcher: Dispatcher): void => {
   ReactInternals.ReactCurrentDispatcher.current = dispatcher;
 };
-
-export const dispatcherIsRegistered = (): boolean =>
-  ReactInternals.ReactCurrentDispatcher.current === dispatcher;

--- a/src/withPreparedEffect.tsx
+++ b/src/withPreparedEffect.tsx
@@ -1,0 +1,28 @@
+import React, { ComponentType, DependencyList, ReactNode } from 'react';
+import { usePreparedEffect } from './index';
+import { PreparedEffectOptions } from './usePreparedEffect';
+
+const withPreparedEffect =
+  <P,>(
+    identifier: string,
+    effect: (props: P) => Promise<void>,
+    depsFn?: (props: P) => DependencyList,
+    opts?: PreparedEffectOptions,
+  ) =>
+  (Component: ComponentType<P>) => {
+    const WrappedComponent = (props: P): ReactNode => {
+      usePreparedEffect(
+        identifier,
+        () => effect(props),
+        depsFn ? depsFn(props) : [],
+        opts,
+      );
+      return <Component {...props} />;
+    };
+    WrappedComponent.displayName = `withPreparedEffect(${
+      Component.displayName || Component.name
+    })`;
+    return WrappedComponent;
+  };
+
+export default withPreparedEffect;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,6 +19,9 @@ export default defineConfig({
       },
     },
   },
-  test: {},
+  test: {
+    globals: true,
+    environment: 'jsdom',
+  },
   plugins: [react()],
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,14 +3,13 @@
 
 
 "@ampproject/remapping@^2.1.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.0.tgz#56c133824780de3174aed5ab6834f3026790154d"
-  integrity sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz"
+  integrity sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==
   dependencies:
-    "@jridgewell/gen-mapping" "^0.1.0"
-    "@jridgewell/trace-mapping" "^0.3.9"
+    "@jridgewell/trace-mapping" "^0.3.0"
 
-"@babel/code-frame@^7.18.6":
+"@babel/code-frame@^7.10.4", "@babel/code-frame@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
   integrity sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==
@@ -201,7 +200,7 @@
     "@babel/plugin-syntax-jsx" "^7.18.6"
     "@babel/types" "^7.18.6"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.9.2":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.9.tgz#b4fcfce55db3d2e5e080d2490f608a3b9f407f4a"
   integrity sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==
@@ -270,14 +269,6 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@jridgewell/gen-mapping@^0.1.0":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz#e5d2e450306a9491e3bd77e323e38d7aff315996"
-  integrity sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==
-  dependencies:
-    "@jridgewell/set-array" "^1.0.0"
-    "@jridgewell/sourcemap-codec" "^1.4.10"
-
 "@jridgewell/gen-mapping@^0.3.2":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz#c1aedc61e853f2bb9f5dfe6d4442d3b565b253b9"
@@ -292,7 +283,7 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
   integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
 
-"@jridgewell/set-array@^1.0.0", "@jridgewell/set-array@^1.0.1":
+"@jridgewell/set-array@^1.0.1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
   integrity sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
@@ -301,6 +292,14 @@
   version "1.4.14"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
+
+"@jridgewell/trace-mapping@^0.3.0":
+  version "0.3.15"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz#aba35c48a38d3fd84b37e66c9c0423f9744f9774"
+  integrity sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.14"
@@ -359,6 +358,39 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
+"@testing-library/dom@^8.5.0":
+  version "8.17.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.17.1.tgz#2d7af4ff6dad8d837630fecd08835aee08320ad7"
+  integrity sha512-KnH2MnJUzmFNPW6RIKfd+zf2Wue8mEKX0M3cpX6aKl5ZXrJM1/c/Pc8c2xDNYQCnJO48Sm5ITbMXgqTr3h4jxQ==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^5.0.0"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.4.4"
+    pretty-format "^27.0.2"
+
+"@testing-library/react@^13.3.0":
+  version "13.3.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-13.3.0.tgz#bf298bfbc5589326bbcc8052b211f3bb097a97c5"
+  integrity sha512-DB79aA426+deFgGSjnf5grczDPiL4taK3hFaa+M5q7q20Kcve9eQottOG5kZ74KEr55v0tU2CQormSSDK87zYQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@testing-library/dom" "^8.5.0"
+    "@types/react-dom" "^18.0.0"
+
+"@tootallnate/once@2":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
+  integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
+
+"@types/aria-query@^4.2.0":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.2.tgz#ed4e0ad92306a704f9fb132a0cfcf77486dbe2bc"
+  integrity sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==
+
 "@types/assert@^1.5.6":
   version "1.5.6"
   resolved "https://registry.yarnpkg.com/@types/assert/-/assert-1.5.6.tgz#a8b5a94ce5fb8f4ba65fdc37fc9507609114189e"
@@ -396,7 +428,7 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
   integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
 
-"@types/react-dom@^18.0.6":
+"@types/react-dom@^18.0.0", "@types/react-dom@^18.0.6":
   version "18.0.6"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.6.tgz#36652900024842b74607a17786b6662dd1e103a1"
   integrity sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==
@@ -510,6 +542,11 @@
     magic-string "^0.26.2"
     react-refresh "^0.14.0"
 
+abab@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
+  integrity sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==
+
 accepts@^1.3.5:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
@@ -518,15 +555,40 @@ accepts@^1.3.5:
     mime-types "~2.1.34"
     negotiator "0.6.3"
 
+acorn-globals@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-6.0.0.tgz#46cdd39f0f8ff08a876619b55f5ac8a6dc770b45"
+  integrity sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==
+  dependencies:
+    acorn "^7.1.1"
+    acorn-walk "^7.1.1"
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
+acorn-walk@^7.1.1:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
+  integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
+
+acorn@^7.1.1:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
+  integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
+
 acorn@^8.7.1:
   version "8.8.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.0.tgz#88c0187620435c7f6015803f5539dae05a9dbea8"
   integrity sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==
+
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
 
 ajv@^6.10.0, ajv@^6.12.4:
   version "6.12.6"
@@ -557,10 +619,20 @@ ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
+
 argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
+aria-query@^5.0.0:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.0.2.tgz#0b8a744295271861e1d933f8feca13f9b70cfdc1"
+  integrity sha512-eigU3vhqSO+Z8BKDnVLN/ompjhf3pYzecKXz8+whRy+9gZu8n1TCGfwzQUUPnqdHl9ax1Hr9031orZ+UOEYr7Q==
 
 array-includes@^3.1.5:
   version "3.1.5"
@@ -593,6 +665,11 @@ assertion-error@^1.1.0:
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
   integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -612,6 +689,11 @@ braces@^3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+browser-process-hrtime@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
+  integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
 
 browserslist@^4.20.2:
   version "4.21.2"
@@ -671,7 +753,7 @@ chalk@^2.0.0:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0:
+chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -712,6 +794,13 @@ color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -754,17 +843,48 @@ cross-spawn@^7.0.2:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+cssom@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.5.0.tgz#d254fa92cd8b6fbd83811b9fbaed34663cc17c36"
+  integrity sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==
+
+cssom@~0.3.6:
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.8.tgz#9f1276f5b2b463f2114d3f2c75250af8c1a36f4a"
+  integrity sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==
+
+cssstyle@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-2.3.0.tgz#ff665a0ddbdc31864b09647f34163443d90b0852"
+  integrity sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
+  dependencies:
+    cssom "~0.3.6"
+
 csstype@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.0.tgz#4ddcac3718d787cf9df0d1b7d15033925c8f29f2"
   integrity sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==
 
-debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
+data-urls@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-3.0.2.tgz#9cf24a477ae22bcef5cd5f6f0bfbc1d2d3be9143"
+  integrity sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==
+  dependencies:
+    abab "^2.0.6"
+    whatwg-mimetype "^3.0.0"
+    whatwg-url "^11.0.0"
+
+debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
+
+decimal.js@^10.3.1:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.0.tgz#97a7448873b01e92e5ff9117d89a7bca8e63e0fe"
+  integrity sha512-Nv6ENEzyPQ6AItkGwLE2PGKinZZ9g59vSh2BeH6NqPu0OTKZ5ruJsVqh/orbAnqXc9pBbgXAIrc2EyaCj8NpGg==
 
 deep-eql@^3.0.1:
   version "3.0.1"
@@ -778,7 +898,7 @@ deep-equal@~1.0.1:
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
   integrity sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==
 
-deep-is@^0.1.3:
+deep-is@^0.1.3, deep-is@~0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
@@ -790,6 +910,11 @@ define-properties@^1.1.3, define-properties@^1.1.4:
   dependencies:
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 delegates@^1.0.0:
   version "1.0.0"
@@ -837,6 +962,18 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dom-accessibility-api@^0.5.9:
+  version "0.5.14"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz#56082f71b1dc7aac69d83c4285eef39c15d93f56"
+  integrity sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==
+
+domexception@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/domexception/-/domexception-4.0.0.tgz#4ad1be56ccadc86fc76d033353999a8037d03673"
+  integrity sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==
+  dependencies:
+    webidl-conversions "^7.0.0"
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -851,6 +988,11 @@ encodeurl@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==
+
+entities@^4.3.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.3.1.tgz#c34062a94c865c322f9d67b4384e4169bcede6a4"
+  integrity sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg==
 
 es-abstract@^1.19.0, es-abstract@^1.19.1, es-abstract@^1.19.2, es-abstract@^1.19.5:
   version "1.20.1"
@@ -1043,6 +1185,18 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
+escodegen@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-2.0.0.tgz#5e32b12833e8aa8fa35e1bf0befa89380484c7dd"
+  integrity sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==
+  dependencies:
+    esprima "^4.0.1"
+    estraverse "^5.2.0"
+    esutils "^2.0.2"
+    optionator "^0.8.1"
+  optionalDependencies:
+    source-map "~0.6.1"
+
 eslint-config-prettier@^8.5.0:
   version "8.5.0"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz#5a81680ec934beca02c7b1a61cf8ca34b66feab1"
@@ -1151,6 +1305,11 @@ espree@^9.3.2:
     acorn-jsx "^5.3.2"
     eslint-visitor-keys "^3.3.0"
 
+esprima@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
+  integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
+
 esquery@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
@@ -1201,7 +1360,7 @@ fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
-fast-levenshtein@^2.0.6:
+fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
@@ -1239,6 +1398,15 @@ flatted@^3.1.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.6.tgz#022e9218c637f9f3fc9c35ab9c9193f05add60b2"
   integrity sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 fresh@~0.5.2:
   version "0.5.2"
@@ -1357,7 +1525,12 @@ globby@^11.1.0:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
-has-bigints@^1.0.1, has-bigints@^1.0.2:
+has-bigints@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.1.tgz#64fe6acb020673e3b78db035a5af69aa9d07b113"
+  integrity sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==
+
+has-bigints@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
   integrity sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==
@@ -1405,6 +1578,13 @@ hoist-non-react-statics@^3.3.0:
   dependencies:
     react-is "^16.7.0"
 
+html-encoding-sniffer@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz#2cb1a8cf0db52414776e5b2a7a04d5dd98158de9"
+  integrity sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==
+  dependencies:
+    whatwg-encoding "^2.0.0"
+
 http-assert@^1.3.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/http-assert/-/http-assert-1.5.0.tgz#c389ccd87ac16ed2dfa6246fd73b926aa00e6b8f"
@@ -1423,6 +1603,30 @@ http-errors@^1.6.3, http-errors@~1.8.0:
     setprototypeof "1.2.0"
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.1"
+
+http-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz#5129800203520d434f142bc78ff3c170800f2b43"
+  integrity sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==
+  dependencies:
+    "@tootallnate/once" "2"
+    agent-base "6"
+    debug "4"
+
+https-proxy-agent@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
+  dependencies:
+    agent-base "6"
+    debug "4"
+
+iconv-lite@0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
 
 ignore@^5.2.0:
   version "5.2.0"
@@ -1541,6 +1745,11 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
+is-potential-custom-element-name@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
+  integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
+
 is-regex@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"
@@ -1598,6 +1807,39 @@ js-yaml@^4.1.0:
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
   dependencies:
     argparse "^2.0.1"
+
+jsdom@^20.0.0:
+  version "20.0.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-20.0.0.tgz#882825ac9cc5e5bbee704ba16143e1fa78361ebf"
+  integrity sha512-x4a6CKCgx00uCmP+QakBDFXwjAJ69IkkIWHmtmjd3wvXPcdOS44hfX2vqkOQrVrq8l9DhNNADZRXaCEWvgXtVA==
+  dependencies:
+    abab "^2.0.6"
+    acorn "^8.7.1"
+    acorn-globals "^6.0.0"
+    cssom "^0.5.0"
+    cssstyle "^2.3.0"
+    data-urls "^3.0.2"
+    decimal.js "^10.3.1"
+    domexception "^4.0.0"
+    escodegen "^2.0.0"
+    form-data "^4.0.0"
+    html-encoding-sniffer "^3.0.0"
+    http-proxy-agent "^5.0.0"
+    https-proxy-agent "^5.0.1"
+    is-potential-custom-element-name "^1.0.1"
+    nwsapi "^2.2.0"
+    parse5 "^7.0.0"
+    saxes "^6.0.0"
+    symbol-tree "^3.2.4"
+    tough-cookie "^4.0.0"
+    w3c-hr-time "^1.0.2"
+    w3c-xmlserializer "^3.0.0"
+    webidl-conversions "^7.0.0"
+    whatwg-encoding "^2.0.0"
+    whatwg-mimetype "^3.0.0"
+    whatwg-url "^11.0.0"
+    ws "^8.8.0"
+    xml-name-validator "^4.0.0"
 
 jsesc@^2.5.1:
   version "2.5.2"
@@ -1689,6 +1931,14 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
+levn@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
+  integrity sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==
+  dependencies:
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
+
 local-pkg@^0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/local-pkg/-/local-pkg-0.4.2.tgz#13107310b77e74a0e513147a131a2ba288176c2f"
@@ -1725,6 +1975,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==
+
 magic-string@^0.26.2:
   version "0.26.2"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.26.2.tgz#5331700e4158cd6befda738bb6b0c7b93c0d4432"
@@ -1755,7 +2010,7 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.18, mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.1.12, mime-types@^2.1.18, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -1811,6 +2066,11 @@ node-releases@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.6.tgz#8a7088c63a55e493845683ebf3c828d8c51c5503"
   integrity sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==
+
+nwsapi@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.1.tgz#10a9f268fbf4c461249ebcfe38e359aa36e2577c"
+  integrity sha512-JYOWTeFoS0Z93587vRJgASD5Ut11fYl5NyihP3KrYBvMe1FRRs6RN7m20SA/16GM4P6hTnZjT+UmDOt38UeXNg==
 
 object-assign@^4.1.1:
   version "4.1.1"
@@ -1891,6 +2151,18 @@ only@~0.0.2:
   resolved "https://registry.yarnpkg.com/only/-/only-0.0.2.tgz#2afde84d03e50b9a8edc444e30610a70295edfb4"
   integrity sha512-Fvw+Jemq5fjjyWz6CpKx6w9s7xxqo3+JCyM0WXWeCSOboZ8ABkyvP8ID4CZuChA/wxSx+XSJmdOm8rGVyJ1hdQ==
 
+optionator@^0.8.1:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
+  integrity sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==
+  dependencies:
+    deep-is "~0.1.3"
+    fast-levenshtein "~2.0.6"
+    levn "~0.3.0"
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
+    word-wrap "~1.2.3"
+
 optionator@^0.9.1:
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.1.tgz#4f236a6373dae0566a6d43e1326674f50c291499"
@@ -1909,6 +2181,13 @@ parent-module@^1.0.0:
   integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
   dependencies:
     callsites "^3.0.0"
+
+parse5@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.0.0.tgz#51f74a5257f5fcc536389e8c2d0b3802e1bfa91a"
+  integrity sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g==
+  dependencies:
+    entities "^4.3.0"
 
 parseurl@^1.3.2:
   version "1.3.3"
@@ -1971,10 +2250,24 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
+prelude-ls@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
+  integrity sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==
+
 prettier@^2.6.2:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
   integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
+
+pretty-format@^27.0.2:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
+  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
+  dependencies:
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
 
 prop-types@^15.6.1, prop-types@^15.8.1:
   version "15.8.1"
@@ -1985,10 +2278,20 @@ prop-types@^15.6.1, prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
-punycode@^2.1.0:
+psl@^1.1.33:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
+  integrity sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==
+
+punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+querystringify@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
+  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -2007,6 +2310,11 @@ react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^17.0.1:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
 react-lifecycles-compat@^3.0.0:
   version "3.0.4"
@@ -2069,6 +2377,11 @@ regexpp@^3.2.0:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
 
+requires-port@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+  integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
+
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
@@ -2127,6 +2440,18 @@ safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+"safer-buffer@>= 2.1.2 < 3.0.0":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+saxes@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/saxes/-/saxes-6.0.0.tgz#fe5b4a4768df4f14a201b1ba6a65c1f3d9988cc5"
+  integrity sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==
+  dependencies:
+    xmlchars "^2.2.0"
 
 scheduler@^0.23.0:
   version "0.23.0"
@@ -2195,6 +2520,11 @@ source-map-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
+source-map@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
 sourcemap-codec@^1.4.8:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
@@ -2203,7 +2533,7 @@ sourcemap-codec@^1.4.8:
 "statuses@>= 1.5.0 < 2", statuses@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
-  integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
+  integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
 string.prototype.matchall@^4.0.7:
   version "4.0.7"
@@ -2268,6 +2598,11 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+symbol-tree@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
+  integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -2300,6 +2635,23 @@ toidentifier@1.0.1:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
+tough-cookie@^4.0.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.2.tgz#e53e84b85f24e0b65dd526f46628db6c85f6b874"
+  integrity sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==
+  dependencies:
+    psl "^1.1.33"
+    punycode "^2.1.1"
+    universalify "^0.2.0"
+    url-parse "^1.5.3"
+
+tr46@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-3.0.0.tgz#555c4e297a950617e8eeddef633c87d4d9d6cbf9"
+  integrity sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==
+  dependencies:
+    punycode "^2.1.1"
+
 tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
@@ -2328,6 +2680,13 @@ type-check@^0.4.0, type-check@~0.4.0:
   integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
   dependencies:
     prelude-ls "^1.2.1"
+
+type-check@~0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
+  integrity sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==
+  dependencies:
+    prelude-ls "~1.1.2"
 
 type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5, type-detect@^4.0.8:
   version "4.0.8"
@@ -2362,6 +2721,11 @@ unbox-primitive@^1.0.2:
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
 
+universalify@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
+  integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
+
 update-browserslist-db@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz#be06a5eedd62f107b7c19eb5bcefb194411abf38"
@@ -2376,6 +2740,14 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+url-parse@^1.5.3:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
+  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
+  dependencies:
+    querystringify "^2.1.1"
+    requires-port "^1.0.0"
 
 v8-compile-cache@^2.0.3:
   version "2.3.0"
@@ -2414,10 +2786,49 @@ vitest@^0.19.1:
     tinyspy "^1.0.0"
     vite "^2.9.12 || ^3.0.0-0"
 
+w3c-hr-time@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz#0a89cdf5cc15822df9c360543676963e0cc308cd"
+  integrity sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==
+  dependencies:
+    browser-process-hrtime "^1.0.0"
+
+w3c-xmlserializer@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-3.0.0.tgz#06cdc3eefb7e4d0b20a560a5a3aeb0d2d9a65923"
+  integrity sha512-3WFqGEgSXIyGhOmAFtlicJNMjEps8b1MG31NCA0/vOF9+nKMUW1ckhi9cnNHmf88Rzw5V+dwIwsm2C7X8k9aQg==
+  dependencies:
+    xml-name-validator "^4.0.0"
+
 webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
   integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
+webidl-conversions@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
+  integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
+
+whatwg-encoding@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz#e7635f597fd87020858626805a2729fa7698ac53"
+  integrity sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==
+  dependencies:
+    iconv-lite "0.6.3"
+
+whatwg-mimetype@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz#5fa1a7623867ff1af6ca3dc72ad6b8a4208beba7"
+  integrity sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==
+
+whatwg-url@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-11.0.0.tgz#0a849eebb5faf2119b901bb76fd795c2848d4018"
+  integrity sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==
+  dependencies:
+    tr46 "^3.0.0"
+    webidl-conversions "^7.0.0"
 
 whatwg-url@^5.0.0:
   version "5.0.0"
@@ -2445,7 +2856,7 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-word-wrap@^1.2.3:
+word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
@@ -2453,7 +2864,22 @@ word-wrap@^1.2.3:
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
-  integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+  integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+
+ws@^8.8.0:
+  version "8.8.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.8.1.tgz#5dbad0feb7ade8ecc99b830c1d77c913d4955ff0"
+  integrity sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==
+
+xml-name-validator@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-4.0.0.tgz#79a006e2e63149a8600f15430f0a4725d1524835"
+  integrity sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==
+
+xmlchars@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
+  integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
 yallist@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
I have added two new functions intended to replace the `prepared` and `dispatched` functions, with an API that more closely matches the way we use the library in lego-webapp. I intend to remove prepared and dispatched, but I figured it was better to do that in a separate update.

The new API is created to mimic how `useEffect` works, except that the effect will be run on the server the first time instead of the client when server-side rendering. In addition i have added a higher order component that wraps the new hook, to make the transition in `lego-webapp` easier.

# API

## `usePreparedEffect()`
It works exactly like a normal `useEffect()` except it runs during `prepare()` instead of on the client when SSR is used.

You might use it like this:
```js
const dispatch = useDispatch();
usePreparedEffect('fetchItems', () => {
  dispatch(fetchAll({ query: props.location.search }));
}, [dispatch, props.location.search]);
```

It also has an option `runSync` which works like `awaitOnSsr` in `prepared`, meaning it awaits the effect before preparing children.

This might be useful in the future, but for the time beeing our routes are basically just compositions of higher order components, which is why i created the `withPreparedEffect` HOC.
## `withPreparedEffect()`
This is basically just a wrapper for adding a `usePreparedEffect()` hook. Just like `usePreparedEffect` it takes an effect function as an argument, and it will get passed all the component's props. It also takes a function that creates the dependency array, which also gets passed the props.

It might be used like this:
```js
export default compose(
  connect(mapStateToProps, mapDispatchToProps),
  withPreparedEffect(
    'fetchItems',
    (props) => {
      props.dispatch(fetchAll({ query: props.location.search }));
    },
    (props) => [props.dispatch, props.location.search],
  )
)(Component)
```
