### PR TITLE
Add option to run prepared effect only on server

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ An optional configuration object that can contain the following properties:
 - `opts.runSync` (default: `false`):
   - `true`: When running `prepare`, the `sideEffect`-promise will be awaited before traversing further down the tree. (because of limitations in the current implementation, effects in the same component will be run in parallel)
   - `false`: When running `prepare` the promise will be awaited in parallell with all other prepared effects after the tree has been traversed.
+- `opts.serverOnly` (default `false`):
+  - When `true` the effect will only ever be run on the server. Any provided deps-array will be ignored, and the effect will not be run if the application is not server-side rendered.
 
 ### `withPreparedEffect(identifier: string, sideEffect: async (props) => Promise<void>, depsFn: (props) => [], opts)(Component)`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webkom/react-prepare",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Prepare you app state for async server-side rendering and more!",
   "type": "module",
   "main": "./dist/react-prepare.umd.cjs",

--- a/src/tests/usePreparedEffect.spec.jsx
+++ b/src/tests/usePreparedEffect.spec.jsx
@@ -181,6 +181,48 @@ describe('usePreparedEffect', () => {
     );
   });
 
+  it('should NOT run effect after rendering on client-side when serverOnly=true', () => {
+    const Component = () => {
+      usePreparedEffect('effect', prepareFunction, undefined, {
+        serverOnly: true,
+      });
+      return <div />;
+    };
+
+    render(<Component />);
+
+    assert(prepareFunction.notCalled, 'prepareFunction has never been called');
+  });
+
+  it('should NOT re-run effect on dep change when serverOnly=true', () => {
+    const Component = ({ prop }) => {
+      usePreparedEffect('effect', prepareFunction, [prop], {
+        serverOnly: true,
+      });
+      return <div />;
+    };
+
+    const { rerender } = render(<Component prop="foo" />);
+    rerender(<Component prop="bar" />);
+
+    assert(prepareFunction.notCalled, 'prepareFunction has never been called');
+  });
+
+  it('should run effect on server when serverOnly=true', () => {
+    const Component = () => {
+      usePreparedEffect('effect', prepareFunction, undefined, {
+        serverOnly: true,
+      });
+      return <div />;
+    };
+
+    prepare(<Component />);
+    assert(prepareFunction.calledOnce, 'prepareFunction was called in prepare');
+
+    render(<Component />);
+    assert(prepareFunction.calledOnce, 'prepareFunction was not called again');
+  });
+
   it('should re-run effect on client after being prepared and dep changed', async () => {
     const Component = ({ prop }) => {
       usePreparedEffect('effect', prepareFunction, [prop]);

--- a/src/usePreparedEffect.ts
+++ b/src/usePreparedEffect.ts
@@ -4,45 +4,51 @@ import { __REACT_PREPARE__ } from './constants';
 
 export interface PreparedEffectOptions {
   runSync?: boolean;
+  serverOnly?: boolean;
 }
 
 const usePreparedEffect = (
   identifier: string,
   prepareFunction: PrepareHookFunction,
   deps?: DependencyList,
-  { runSync = false }: PreparedEffectOptions = {},
+  { runSync = false, serverOnly = false }: PreparedEffectOptions = {},
 ): void => {
   // keep track of whether it is the initial effect-run or not, as only the first run is affected by server-preparing
   const isInitialRunOnClient = useRef(true);
 
-  const effect: EffectCallback = () => {
-    const preparedEffects = window[__REACT_PREPARE__]?.preparedEffects;
-
-    const didRunOnServer = preparedEffects?.includes(identifier);
-
-    // If this is a re-run of the effect on the client, the dependency array must have changed, and we want to run the prepare function again.
-    // We also want to run the prepare function on the client if it was not prepared on the server.
-    const shouldRunEffect = !isInitialRunOnClient.current || !didRunOnServer;
-
-    if (shouldRunEffect) {
-      prepareFunction();
-    }
-
-    isInitialRunOnClient.current = false;
-
-    // remove the effect from the list of prepared effects on cleanup, such that it will be re-run if the component re-mounts.
-    return () => {
-      if (
-        window[__REACT_PREPARE__] &&
-        window[__REACT_PREPARE__].preparedEffects.includes(identifier)
-      ) {
-        window[__REACT_PREPARE__].preparedEffects.splice(
-          window[__REACT_PREPARE__].preparedEffects.indexOf(identifier),
-          1,
-        );
+  const effect: EffectCallback = serverOnly
+    ? () => {
+        /* noop */
       }
-    };
-  };
+    : () => {
+        const preparedEffects = window[__REACT_PREPARE__]?.preparedEffects;
+
+        const didRunOnServer = preparedEffects?.includes(identifier);
+
+        // If this is a re-run of the effect on the client, the dependency array must have changed, and we want to run the prepare function again.
+        // We also want to run the prepare function on the client if it was not prepared on the server.
+        const shouldRunEffect =
+          !isInitialRunOnClient.current || !didRunOnServer;
+
+        if (shouldRunEffect) {
+          prepareFunction();
+        }
+
+        isInitialRunOnClient.current = false;
+
+        // remove the effect from the list of prepared effects on cleanup, such that it will be re-run if the component re-mounts.
+        return () => {
+          if (
+            window[__REACT_PREPARE__] &&
+            window[__REACT_PREPARE__].preparedEffects.includes(identifier)
+          ) {
+            window[__REACT_PREPARE__].preparedEffects.splice(
+              window[__REACT_PREPARE__].preparedEffects.indexOf(identifier),
+              1,
+            );
+          }
+        };
+      };
 
   // Set react-prepare specific properties on the effect function, so that we can identify it as a prepare-hook effect and run the prepare function in the dispatcher.
   (effect as PrepareHookEffect)[__REACT_PREPARE__] = {


### PR DESCRIPTION
The login logic of lego-webapp requires a set of async actions to be performed in a specific sequence on the server, and the client if not server side rendered.

The required client-side logic wasn't possible to implement with react-prepare, so the solution that has been used is run these actions with react-prepare only on the server, and implement the same logic separately for the client. This PR adds the option `serverOnly`, that makes the prepare-effect run only on the server, to `usePreparedEffect` and `withPreparedEffect`, such that the same logic can still be used when updating react-prepare in lego-webapp.

Also bumps version to 0.10.1