### PR TITLE
Export type for prepare and usePreparedEffect options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webkom/react-prepare",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Prepare you app state for async server-side rendering and more!",
   "type": "module",
   "main": "./dist/react-prepare.umd.cjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,10 @@ import withPreparedEffect from './withPreparedEffect';
 import dispatched from './dispatched';
 import prepare from './prepare';
 import prepared from './prepared';
+import type { PrepareOptions } from './prepare';
+import type { PreparedEffectOptions } from './usePreparedEffect';
 
 export { dispatched, prepare, prepared, usePreparedEffect, withPreparedEffect };
+export type { PrepareOptions, PreparedEffectOptions };
 
 export default prepare;

--- a/src/prepare.ts
+++ b/src/prepare.ts
@@ -180,7 +180,7 @@ async function prepareElement(
   }
 }
 
-interface PrepareOptions {
+export interface PrepareOptions {
   errorHandler: (error: unknown) => void;
 }
 


### PR DESCRIPTION
These types are nice to have in the user-application in case you want to handle a typed an options-object before passing it to the respective function. 