### PR TITLE
Fix typescript types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webkom/react-prepare",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Prepare you app state for async server-side rendering and more!",
   "type": "module",
   "main": "./dist/react-prepare.umd.cjs",

--- a/src/prepare.ts
+++ b/src/prepare.ts
@@ -209,7 +209,7 @@ async function internalPrepare(
 async function prepare(
   element: ReactNode,
   options: Partial<PrepareOptions> = {},
-): Promise<unknown> {
+): Promise<string> {
   const fullOptions: PrepareOptions = {
     errorHandler: (error) => {
       throw error;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -56,7 +56,7 @@ export type ClassComponentInstance<P, S = unknown> = Omit<
   getChildContext?: () => PrepareContext;
 };
 
-export type PrepareHookFunction = () => Promise<void>;
+export type PrepareHookFunction = () => Promise<unknown>;
 
 export type PrepareHookEffect = EffectCallback & {
   [__REACT_PREPARE__]: {

--- a/src/withPreparedEffect.tsx
+++ b/src/withPreparedEffect.tsx
@@ -5,7 +5,7 @@ import { PreparedEffectOptions } from './usePreparedEffect';
 const withPreparedEffect =
   <P,>(
     identifier: string,
-    effect: (props: P) => Promise<void>,
+    effect: (props: P) => Promise<unknown>,
     depsFn?: (props: P) => DependencyList,
     opts?: PreparedEffectOptions,
   ) =>


### PR DESCRIPTION
Now that lego-webapp uses typescript i noticed some wrong types.
- `prepare` had return type `Promise<unknown>` instead of `Promise<string>`.
- Prepare-effects were typed as `() => Promise<void>`, which does make some sense, but is annoying as it doesn't allow you to return the result of `Promise.all` which is a list. I changed it to `() => Promise<unknown>` which will allow any return value.