### PR TITLE
Fix crash when using hooks inside forwardRef()-components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webkom/react-prepare",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Prepare you app state for async server-side rendering and more!",
   "type": "module",
   "main": "./dist/react-prepare.umd.cjs",


### PR DESCRIPTION
This caused react-prepare to fail on all pages with `react-final-form` forms in `lego-webapp`

Resolves ABA-686