### PR TITLE
Add support for Suspense and lazy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webkom/react-prepare",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Prepare you app state for async server-side rendering and more!",
   "type": "module",
   "main": "./dist/react-prepare.umd.cjs",

--- a/src/utils/getElementType.ts
+++ b/src/utils/getElementType.ts
@@ -11,6 +11,7 @@ export enum ELEMENT_TYPE {
   MEMO = 7,
   FUNCTION_COMPONENT = 8,
   CLASS_COMPONENT = 9,
+  LAZY = 10,
 }
 
 function isTextNode(element: ReactNode): element is string | number {
@@ -41,6 +42,8 @@ export default function getElementType(element: ReactNode): ELEMENT_TYPE {
       return ELEMENT_TYPE.FORWARD_REF;
     } else if (type.$$typeof.toString() === 'Symbol(react.memo)') {
       return ELEMENT_TYPE.MEMO;
+    } else if (type.$$typeof.toString() === 'Symbol(react.lazy)') {
+      return ELEMENT_TYPE.LAZY;
     }
   } else if (typeof element.type === 'function') {
     if (!element.type.prototype || !('render' in element.type.prototype)) {

--- a/src/utils/reactInternalTypes.d.ts
+++ b/src/utils/reactInternalTypes.d.ts
@@ -6,6 +6,7 @@ import React, {
   ExoticComponent,
   ForwardedRef,
   ForwardRefRenderFunction,
+  LazyExoticComponent,
   MemoExoticComponent,
   Provider,
   ProviderProps,
@@ -86,4 +87,17 @@ export type ForwardRefElement<P = unknown> = ReactElement<
 export type MemoElement<P = unknown> = ReactElement<
   P,
   MemoExoticComponent<ComponentType<P>>
+>;
+
+type LazyPayload<P> = {
+  _status: number;
+  _result: { default: ComponentType<P> };
+};
+
+export type LazyElement<P = unknown> = ReactElement<
+  P,
+  LazyExoticComponent<ComponentType<P>> & {
+    _payload: LazyPayload<P>;
+    _init: (payload: LazyPayload<P>) => unknown;
+  }
 >;


### PR DESCRIPTION
Needed for lazy loaded pages in the `lego-webapp` vite migration.

How does it work? Who knows... but the tests are passing and it works for me in the lego-webapp vite branch